### PR TITLE
Move C++ code into `.cpp` file out of `.hpp`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,14 @@ add_custom_command(
 )
 
 python_add_library(irimager MODULE
-  src/nqm/irimager/irimager.cpp "${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
+  src/nqm/irimager/irimager.cpp
+  src/nqm/irimager/irimager_class.cpp
+  "${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
   WITH_SOABI
+)
+set_target_properties(irimager PROPERTIES
+  PRIVATE_HEADER
+    "src/nqm/irimager/irimager_class.hpp;${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
 )
 target_link_libraries(irimager PRIVATE pybind11::headers)
 target_compile_features(irimager PRIVATE cxx_std_17)

--- a/src/nqm/irimager/irimager_class.cpp
+++ b/src/nqm/irimager/irimager_class.cpp
@@ -1,0 +1,60 @@
+#include "./irimager_class.hpp"
+
+IRImager::IRImager() = default;
+
+IRImager::IRImager(const std::filesystem::path &xml_path) {
+    std::ifstream xml_stream(xml_path, std::fstream::in);
+
+    std::string xml_header(5, '\0');
+    xml_stream.read(xml_header.data(), xml_header.size());
+    if (xml_header != std::string("<?xml")) {
+        throw std::runtime_error("Invalid XML file: The given XML file does not start with '<?xml'");
+    }
+}
+
+void IRImager::start_streaming() {
+    streaming = true;
+}
+
+void IRImager::stop_streaming() {
+    streaming = false;
+}
+
+IRImager* IRImager::_enter_() {
+    start_streaming();
+    return this;
+}
+
+void IRImager::_exit_(
+    [[maybe_unused]] const std::optional<pybind11::type> &exc_type,
+    [[maybe_unused]] const std::optional<pybind11::error_already_set> &exc_value,
+    [[maybe_unused]] const pybind11::object &traceback) {
+
+    stop_streaming();
+}
+
+std::tuple<
+    pybind11::array_t<uint16_t>,
+    std::chrono::system_clock::time_point
+> IRImager::get_frame() {
+    if (!streaming) {
+        throw std::runtime_error("IRIMAGER_STREAMOFF: Not streaming");
+    }
+
+    auto frame_size = std::array<ssize_t, 2>{128, 128};
+    auto my_array = pybind11::array_t<uint16_t>(frame_size);
+
+    auto r = my_array.mutable_unchecked<frame_size.size()>();
+
+    for (ssize_t i = 0; i < frame_size[0]; i++) {
+        for (ssize_t j = 0; j < frame_size[1]; j++) {
+            r(i, j) = 1800 * std::pow(10, get_temp_range_decimal());
+        }
+    }
+
+    return std::make_tuple(my_array, std::chrono::system_clock::now());
+}
+
+short IRImager::get_temp_range_decimal() {
+    return 1;
+}

--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -11,19 +11,11 @@
  */
 class IRImager {
     public:
-    IRImager() = default;
+    IRImager();
     /**
      * Loads the configuration for an IR Camera from the given XML file
      */
-    IRImager(const std::filesystem::path &xml_path) {
-        std::ifstream xml_stream(xml_path, std::fstream::in);
-
-        std::string xml_header(5, '\0');
-        xml_stream.read(xml_header.data(), xml_header.size());
-        if (xml_header != std::string("<?xml")) {
-            throw std::runtime_error("Invalid XML file: The given XML file does not start with '<?xml'");
-        }
-    }
+    IRImager(const std::filesystem::path &xml_path);
 
     /**
      * Start video grabbing
@@ -34,28 +26,19 @@ class IRImager {
      * @throws RuntimeError if streaming cannot be started, e.g. if the camera
      *                      is not connected.
      */
-    void start_streaming() {
-        streaming = true;
-    }
+    void start_streaming();
 
     /**
      * Stop video grabbing
      */
-    void stop_streaming() {
-        streaming = false;
-    }
+    void stop_streaming();
 
-    IRImager* _enter_() {
-        start_streaming();
-        return this;
-    }
+    IRImager* _enter_();
 
     void _exit_(
-        [[maybe_unused]] const std::optional<pybind11::type> &exc_type,
-        [[maybe_unused]] const std::optional<pybind11::error_already_set> &exc_value,
-        [[maybe_unused]] const pybind11::object &traceback) {
-        stop_streaming();
-    }
+        const std::optional<pybind11::type> &exc_type,
+        const std::optional<pybind11::error_already_set> &exc_value,
+        const pybind11::object &traceback);
 
     /**
      * Return a frame
@@ -69,24 +52,10 @@ class IRImager {
      *           actual temperature in degrees Celcius.
      *         2. The time the image was taken.
      */
-    std::tuple<pybind11::array_t<uint16_t>, std::chrono::system_clock::time_point> get_frame() {
-        if (!streaming) {
-            throw std::runtime_error("IRIMAGER_STREAMOFF: Not streaming");
-        }
-
-        auto frame_size = std::array<ssize_t, 2>{128, 128};
-        auto my_array = pybind11::array_t<uint16_t>(frame_size);
-
-        auto r = my_array.mutable_unchecked<frame_size.size()>();
-
-        for (ssize_t i = 0; i < frame_size[0]; i++) {
-            for (ssize_t j = 0; j < frame_size[1]; j++) {
-                r(i, j) = 1800 * std::pow(10, get_temp_range_decimal());
-            }
-        }
-
-        return std::make_tuple(my_array, std::chrono::system_clock::now());
-    }
+    std::tuple<
+        pybind11::array_t<uint16_t>,
+        std::chrono::system_clock::time_point
+    > get_frame() ;
 
     /**
      * The number of decimal places in the thermal data
@@ -96,9 +65,7 @@ class IRImager {
      * :py:meth:`~IRImager.get_temp_range_decimal` to get the actual
      * temperature in degrees Celcius.
      */
-    short get_temp_range_decimal() {
-        return 1;
-    }
+    short get_temp_range_decimal();
 
 private:
     bool streaming = false;


### PR DESCRIPTION
Split up the definition and the declaration of the `IRImager` class.

In C++ (at least before the C++20 modules feature) and C, it's normal practice to only put declarations into the `.h`/`.hpp` header file. This basically acts as a symbol for the function in the shared library.

Then, the actual definition of the function only goes into a `.c`/`.cpp` file.

You can think of it like how in TypeScript/Python, type stubs may be separate from the actual JavaScript/Python implementation.