### PR TITLE
build: fix running CMake without `scikit-build-core`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,15 @@ string(REGEX MATCH
     "${SKBUILD_PROJECT_VERSION}"
 )
 
+if (NOT SKBUILD)
+  message(WARNING "\
+  This CMake file is meant to be executed using 'scikit-build-core'. You should
+  probably be running this CMake file by using a command like `pip install .`.
+  ")
+endif()
+
 project(
-  ${SKBUILD_PROJECT_NAME}
+  "${SKBUILD_PROJECT_NAME}"
   VERSION "${skbuild_project_numeric_version}"
   LANGUAGES CXX)
 


### PR DESCRIPTION
Most C++ projects are configured and built using CMake with something like: `cmake -S . -B build/ && cmake --build build/`.

However, this project is a bit unusual, since we expect that people **don't** call CMake directly. Instead, they'll run `scikit-build-core`, which will then call CMake with some special variables. Because of that, we should warn the user if they run CMake without using `scikit-build-core`.

As an example of stuff that might go wrong if we don't use `scikit-build-core`, I've also fixed a bug (due to not escaping a param) that was causing CMake to crash in this case.