### PR TITLE
ci: build aarch64 wheels in GitHub Actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ docs = [
 [tool.cibuildwheel]
 build = "cp*-manylinux_*" # any standard CPython Linux
 archs = [
-    "auto64" # skip building 32-bit builds
+    "auto64", # skip building 32-bit builds, even if our OS supports it
+    "aarch64",
+    "x86_64",
 ]
 test-command = "pytest {project}/tests"
 test-requires = "pytest"


### PR DESCRIPTION
Build `aarch64` wheels in GitHub Actions, which is needed for things like the NVIDIA JETSON box, or Raspberry Pi 4s.

This uses emulation in GitHub Actions, so it should be very slow, but it should work.

See https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation

---

CI seems to be very slow, but if it ever passes, you're welcome to open this PR and merge it!