### PR TITLE
Build `aarch64` wheels in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   libirimager_version: "4.1.1"
+  libirmager_arches: 'amd64 arm64'
 
 jobs:
   build_wheels:
@@ -31,7 +32,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "${{ runner.temp }}/libirimager"
-          key: libirimager-${{ env.libirimager_version }}
+          key: libirimager-${{ env.libirimager_version }}-${{ env.libirmager_arches }}
 
       - name: Download libirimager ${{ env.libirimager_version }}
         if: steps.libirimager-cache.outputs.cache-hit != 'true'
@@ -39,7 +40,7 @@ jobs:
         run: |
           mkdir -p libirimager
           cd libirimager
-          for ARCH in "amd64"; do
+          for ARCH in ${libirmager_arches}; do
             wget "http://ftp.evocortex.com/libirimager-4.1.1-${ARCH}.deb"
           done
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,9 @@ docs = [
 [tool.cibuildwheel]
 build = "cp*-manylinux_*" # any standard CPython Linux
 archs = [
-    "auto64" # skip building 32-bit builds
+    "auto64", # skip building 32-bit builds, even if our OS supports it
+    "aarch64",
+    "x86_64",
 ]
 test-command = "pytest {project}/tests"
 test-requires = "pytest"


### PR DESCRIPTION
Build `aarch64` wheels in GitHub Actions using `cibuildwheel`.

This can be easily done by setting up QEMU emulation for `cibuildwheel`, which then lets us run aarch64 code on GitHub Actions' x86_64 servers.

I did manage to spot a bug in one of our dependencies. [`libclang`'s 16.0.6](https://pypi.org/project/libclang/16.0.6/)'s release has a broken `manylinux2014` wheel for aarch64, see https://github.com/sighingnow/libclang/issues/59. This issue will not be trivial to fix. However, we can work around it, since `libclang` 16.0.0 seems to be fine.

I've patched [`pybind11_mkdoc`](https://pypi.org/project/pybind11_mkdoc) so that `libclang < 16.0.6` is used, so that we don't use the broken version. See https://github.com/aloisklink/pybind11_mkdoc/commit/8461768849fa45268fc588a6f1377c14e461cbca