### PR TITLE
Add `get_library_version()` function

### DIFF
--- a/src/nqm/irimager/__init__.pyi
+++ b/src/nqm/irimager/__init__.pyi
@@ -65,3 +65,11 @@ class IRImager:
         :py:meth:`~IRImager.get_temp_range_decimal` to get the actual
         temperature in degrees Celcius.
         """
+    @staticmethod
+    def get_library_version(self) -> typing.Union[str, typing.Literal["MOCKED"]]:
+        """Get the version of the libirimager library.
+
+        Returns:
+            the version of the libirmager library, or "MOCKED" if the library
+            has been mocked.
+        """

--- a/src/nqm/irimager/irimager.cpp
+++ b/src/nqm/irimager/irimager.cpp
@@ -31,6 +31,7 @@ to control these cameras.)";
         .def(pybind11::init<const std::filesystem::path &>(), DOC(IRImager, IRImager, 2))
         .def("get_frame", &IRImager::get_frame, DOC(IRImager, get_frame))
         .def("get_temp_range_decimal", &IRImager::get_temp_range_decimal, DOC(IRImager, get_temp_range_decimal))
+        .def_static("get_library_version", &IRImager::get_library_version, DOC(IRImager, get_library_version))
         .def("start_streaming", &IRImager::start_streaming, DOC(IRImager, start_streaming))
         .def("stop_streaming", &IRImager::stop_streaming, DOC(IRImager, stop_streaming))
         .def("__enter__", &IRImager::_enter_, pybind11::return_value_policy::reference_internal)

--- a/src/nqm/irimager/irimager_class.cpp
+++ b/src/nqm/irimager/irimager_class.cpp
@@ -1,5 +1,6 @@
 #include "./irimager_class.hpp"
 #include "libirimager/IRDevice.h"
+#include "libirimager/IRImager.h"
 
 struct IRImager::impl final {
     bool streaming = false;
@@ -71,4 +72,8 @@ std::tuple<
 
 short IRImager::get_temp_range_decimal() {
     return 1;
+}
+
+std::string_view IRImager::get_library_version() {
+    return evo::IRImager::getVersion();
 }

--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
+#include <string_view>
 
 #include <pybind11/numpy.h>
 
@@ -83,6 +84,14 @@ class IRImager {
      * to get the actual temperature in degrees Celcius.
      */
     short get_temp_range_decimal();
+
+    /**
+     * Get the version of the libirimager library.
+     *
+     * @returns the version of the libirmager library, or "MOCKED" if the
+     * library has been mocked.
+     */
+    static std::string_view get_library_version();
 
 private:
     /** pImpl implementation */

--- a/src/nqm/irimager/irimager_mock.cpp
+++ b/src/nqm/irimager/irimager_mock.cpp
@@ -77,3 +77,7 @@ std::tuple<
 short IRImager::get_temp_range_decimal() {
     return 1;
 }
+
+std::string_view IRImager::get_library_version() {
+    return "MOCKED";
+}

--- a/tests/test_irimager.py
+++ b/tests/test_irimager.py
@@ -60,3 +60,8 @@ def test_irimager_get_temp_range_decimal():
 
     assert irimager.get_temp_range_decimal() >= 0
     assert isinstance(irimager.get_temp_range_decimal(), int)
+
+
+def test_irimager_get_library_version():
+    """Tests that nqm.irimager.IRImager#get_library_version returns a string"""
+    assert isinstance(IRImager.get_library_version(), str)


### PR DESCRIPTION
**Blocked by:**
  - #14
  - #15
  - #31 

---

Add a function called `get_library_version()` that can be used to get the version of the underlying libirimager library.

When the libirimager library has been mocked, it instead returns "MOCKED".

---

Because the `evo::IRImager::getVersion()` function returns a `std::string`, it's a good way to test whether we're compiling with the correct `_GLIBCXX_USE_CXX11_ABI=0` or `_GLIBCXX_USE_CXX11_ABI=1` flag, see https://github.com/nqminds/nqm-irimager/pull/14#issuecomment-1658270382
