### PR TITLE
ci: build and test decontainer setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,28 @@ jobs:
           fi
       - name: Test with pytest
         run: pdm run pytest
+
+  dev-container:
+    name: Test and build the dev-container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and run Dev Container task
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository_owner }}/nqm-irimager-devcontainer
+          cacheFrom: ghcr.io/${{ github.repository_owner }}/nqm-irimager-devcontainer
+          # only push new image if this is a on the `main` branch
+          refFilterForPush: "refs/heads/main"
+          runCmd: |
+            pdm install
+            pdm run pytest


### PR DESCRIPTION
In https://github.com/nqminds/nqm-irimager/pull/11, we added a [developer container](https://containers.dev/) config that can be used to automatically setup the developer environment (useful since the `irimager` Debian package is broken in many environments, so it's non-trivial to install). However, this was never tested.

This PR will add a GitHub Action that automatically:
  - Builds the `.devcontainer` setup
  - Tests the `.devcontainer` setup
  - Uploads the created image to GHCR as [`nqminds/nqm-irimager-devcontainer`](https://github.com/nqminds/nqm-irimager/pkgs/container/nqm-irimager-devcontainer), if on the `main` branch (can be used for caching/faster builds).

This uses the [`devcontainers/ci` action][1].

[1]: https://github.com/devcontainers/ci