### PR TITLE
doc: fix ReST broken section title

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Welcome to nqm.irimager's documentation!
-=======================================
+========================================
 
 .. include:: ../README.md
    :parser: myst_parser.sphinx_


### PR DESCRIPTION
Fix the following Sphinx warning:

```
/nqm-irimager/docs/index.rst:7: WARNING: Title underline too short.

Welcome to nqm.irimager's documentation!
=======================================
```