### PR TITLE
build(docs): fix sphinx autodocs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ jobs:
           SKBUILD_CMAKE_ARGS: "-DIRImager_mock=ON"
       - name: Build documentation into `build/` folder
         run: |
-          pdm run sphinx-apidoc --implicit-namespaces -o docs/apidoc src/nqm/
           pdm run sphinx-build -M html docs/ build/
       - name: Upload docs
         uses: actions/upload-pages-artifact@v1

--- a/README.md
+++ b/README.md
@@ -87,6 +87,5 @@ documentation in the `docs/` directory.
 automatically parses Google-style Python docstrings.
 
 ```bash
-pdm run .venv/bin/sphinx-apidoc --implicit-namespaces -o docs/apidoc src/nqm/
-pdm run .venv/bin/sphinx-build -M html docs/ build/
+pdm run sphinx-build -M html docs/ build/
 ```

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,0 @@
-# generated with sphinx-apidoc
-/apidoc

--- a/docs/apidoc/modules.rst
+++ b/docs/apidoc/modules.rst
@@ -1,0 +1,7 @@
+nqm
+===
+
+.. toctree::
+   :maxdepth: 4
+
+   nqm

--- a/docs/apidoc/nqm.irimager.rst
+++ b/docs/apidoc/nqm.irimager.rst
@@ -1,0 +1,10 @@
+nqm.irimager package
+====================
+
+Module contents
+---------------
+
+.. automodule:: nqm.irimager
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/apidoc/nqm.rst
+++ b/docs/apidoc/nqm.rst
@@ -1,0 +1,12 @@
+nqm namespace
+=============
+
+.. py:module:: nqm
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   nqm.irimager


### PR DESCRIPTION
The [`sphinx-apidoc`][1] command does not work with Python C extension modules.

Instead, we have to manually create all of Sphinx source files.

This isn't too difficult, I'm just committing the sources created by running `pdm run sphinx-apidoc --implicit-namespaces -o docs/apidoc src/nqm/` on commit fc8f33c31177ca0856655c8ed8712f2a89ed70c5, before we switched to using a C module.

The only annoying thing will be updated these files in the future, but I'm not planning on adding any other Python modules to this package, so this should be fine.

[1]: https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html