### PR TITLE
build: remove `pkg-config` build requirement

### DIFF
--- a/cmake/FindLibUsb.cmake
+++ b/cmake/FindLibUsb.cmake
@@ -21,6 +21,8 @@ This module will set the following variables in your project:
 
 ``LibUsb_FOUND``
   True if LibUsb was found, false otherwise.
+``LibUsb_INCLUDE_DIRS``
+  LibUSB include directories.
 ``LibUsb_LIBRARIES``
   LibUSB library, and it's dependencies.
 ``LibUsb_VERSION``
@@ -29,28 +31,31 @@ This module will set the following variables in your project:
 #]=======================================================================]
 cmake_minimum_required(VERSION 3.15...3.26)
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(LibUsb REQUIRED libusb IMPORTED_TARGET)
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_LibUsb QUIET libusb IMPORTED_TARGET)
 
-if(_LibUsb_FOUND)
-  set(LibUsb_FOUND "${_LibUsb_FOUND}")
-  set(LibUsb_LIBRARIES "${_LibUsb_LINK_LIBRARIES}")
-  set(LibUsb_VERSION "${_LibUsb_VERSION}")
-endif(_LibUsb_FOUND)
+find_path(LibUsb_INCLUDE_DIRS NAMES usb.h HINTS "${PC_LibUsb_INCLUDE_DIRS}")
+find_library(LibUsb_LIBRARIES NAMES usb HINTS "${PC_LibUsb_LIBRARY_DIRS}")
+
+set(LibUsb_VERSION "${PC_LibUsb_VERSION}")
 
 #-----------------------------------------------------------------------------
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibUsb
   FOUND_VAR LibUsb_FOUND
   REQUIRED_VARS
-    LibUsb_LIBRARIES
+    LibUsb_INCLUDE_DIRS LibUsb_LIBRARIES
   VERSION_VAR
     LibUsb_VERSION
 )
 #-----------------------------------------------------------------------------
 if(LibUsb_FOUND)
   if(NOT TARGET LibUsb::LibUsb)
-    add_library(LibUsb::LibUsb INTERFACE IMPORTED)
-    target_link_libraries(LibUsb::LibUsb INTERFACE PkgConfig::LibUsb)
+    add_library(LibUsb::LibUsb UNKNOWN IMPORTED)
+    set_target_properties(LibUsb::LibUsb PROPERTIES
+      IMPORTED_LOCATION "${LibUsb_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${LibUsb_INCLUDE_DIRS}"
+      INTERFACE_COMPILE_DEFINITIONS "${PC_LibUsb_CFLAGS_OTHER}"
+    )
   endif()
 endif(LibUsb_FOUND)


### PR DESCRIPTION
Currently, the `FindLibUsb.cmake` script requires [`pkg-config`](https://manpages.ubuntu.com/manpages/jammy/en/man1/pkg-config.1.html), as it loads everything from
`/usr/lib/x86_64-linux-gnu/pkgconfig/libusb-1.0.pc`.

However, some computers don't have `pkg-config` pre-installed.

Instead, we can change the `FindLibUsb.cmake` script so that it uses `pkg-config`, but will fallback to manually searching for the files if it can't find anything.