### PR TITLE
build: compile with `-fvisibility=hidden`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ python_add_library(irimager MODULE
 set_target_properties(irimager PROPERTIES
   PRIVATE_HEADER
     "src/nqm/irimager/irimager_class.hpp;${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
+  CXX_VISIBILITY_PRESET "hidden"
 )
 target_link_libraries(irimager PRIVATE pybind11::headers)
 


### PR DESCRIPTION
This is recommended by pybind11 and greatly reduces our binary sizes. Additionally, it prevents GCC from printing some warnings.

See: https://pybind11.readthedocs.io/en/stable/faq.html#faq-symhidden