### PR TITLE
fix: fix the types of the `__exit__()` function

### DIFF
--- a/src/nqm/irimager/irimager_class.cpp
+++ b/src/nqm/irimager/irimager_class.cpp
@@ -41,8 +41,8 @@ IRImager* IRImager::_enter_() {
 
 void IRImager::_exit_(
     [[maybe_unused]] const std::optional<pybind11::type> &exc_type,
-    [[maybe_unused]] const std::optional<pybind11::error_already_set> &exc_value,
-    [[maybe_unused]] const pybind11::object &traceback) {
+    [[maybe_unused]] const std::optional<pybind11::object> &exc_value,
+    [[maybe_unused]] const std::optional<pybind11::object> &traceback) {
 
     stop_streaming();
 }

--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -54,8 +54,8 @@ class IRImager {
 
     void _exit_(
         const std::optional<pybind11::type> &exc_type,
-        const std::optional<pybind11::error_already_set> &exc_value,
-        const pybind11::object &traceback);
+        const std::optional<pybind11::object> &exc_value,
+        const std::optional<pybind11::object> &traceback);
 
     /**
      * Return a frame

--- a/src/nqm/irimager/irimager_mock.cpp
+++ b/src/nqm/irimager/irimager_mock.cpp
@@ -39,8 +39,8 @@ IRImager* IRImager::_enter_() {
 
 void IRImager::_exit_(
     [[maybe_unused]] const std::optional<pybind11::type> &exc_type,
-    [[maybe_unused]] const std::optional<pybind11::error_already_set> &exc_value,
-    [[maybe_unused]] const pybind11::object &traceback) {
+    [[maybe_unused]] const std::optional<pybind11::object> &exc_value,
+    [[maybe_unused]] const std::optional<pybind11::object> &traceback) {
 
     stop_streaming();
 }

--- a/tests/test_irimager.py
+++ b/tests/test_irimager.py
@@ -38,6 +38,15 @@ def test_get_frame_in_context_manager():
         irimager.get_frame()
 
 
+def test_context_manager_handles_error():
+    """Tests whether the `__exit__` dunder can handle an error"""
+    irimager = IRImager()
+
+    with pytest.raises(RuntimeError, match="Test Exception, should be thrown"):
+        with irimager:
+            raise RuntimeError("Test Exception, should be thrown")
+
+
 def test_irimager_get_frame():
     """Tests nqm.irimager.IRImager#get_frame"""
     irimager = IRImager()


### PR DESCRIPTION
Currently, the following code does not work:

```python
irimager = nqm.irimager.IRImager()
with irimager:
    raise Error("This error breaks the context manager")
```

The following error is then thrown:

```
TypeError: __exit__(): incompatible function arguments. The following argument types are supported:
E               1. (self: nqm.irimager.IRImager, arg0: Optional[type], arg1: Optional[error_already_set], arg2: object) -> None
E
E           Invoked with: <nqm.irimager.IRImager object at 0xffff7d509970>, ...
```

This is because pybind11 does not map the Python exception to a `pybind11::error_already_set` C++ type in this context.

Instead, we need to declare our `__exit__()` function to take a generic `pybind11::object` type.

See https://stackoverflow.com/a/76853640/10149169.