### PR TITLE
Document the licenses of the build binary

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,11 @@ API Documentation
 
    apidoc/modules
 
+.. toctree::
+   :hidden:
+
+   licenses
+
 Indices and tables
 ==================
 

--- a/docs/licenses.rst
+++ b/docs/licenses.rst
@@ -1,0 +1,86 @@
+========
+Licenses
+========
+
+Source-code licenses
+====================
+
+The following licenses are taken from the ``LICENSES/`` folder and represent
+the licenses that subsets of the source-code are available under.
+
+Please see each individual file for their ``# SPDX-License-Identifier:`` and
+``# SPDX-FileCopyrightText`` SPDX tags to see which files these licenses cover.
+
+``LICENSES/MIT.txt``
+--------------------
+
+.. include:: ../LICENSES/MIT.txt
+   :literal:
+
+``LICENSES/BSD-3-Clause.txt``
+-----------------------------
+
+.. include:: ../LICENSES/BSD-3-Clause.txt
+   :literal:
+
+Binary licenses
+===============
+
+The following licenses apply to the built binaries, due to static/dynamic
+linking.
+
+libirmager
+----------
+
+The IRImagerDirect SDK library is used under the **BSD-2-Clause** license, see
+`<http://ftp.evocortex.com/freebsd.txt>`_.
+
+  Copyright (c) 2016-2017, Optris GmbH / Evocortex GmbH
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  The views and conclusions contained in the software and documentation are
+  those of the authors and should not be interpreted as representing official
+  policies, either expressed or implied, of the FreeBSD Project.
+
+libudev
+-------
+
+libudev is dynamically linked, as it is required by the IRImagerDirect SDK.
+
+Some udev sources are licensed under **GPL-2.0-or-later**, so the
+udev binaries as a whole are also distributed under **GPL-2.0-or-later**.
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+  USA.

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "test", "lint", "types", "docs", "cibuildwheel"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:f657f4c30a7608cec346eddbf06af7d9dc6656fd2820a86e470950f350e8c2a3"
+content_hash = "sha256:3a45fa5b48e41e847b0ff95296d26adf4dfae10bee29650274a0678e9dcb3a80"
 
 [[package]]
 name = "alabaster"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
 wheel.packages = [ "src/nqm" ]
-wheel.license-files = [ "LICENSES/*" ]
+wheel.license-files = [ "LICENSES/*", "docs/licenses.rst" ]
 cmake.targets = ["irimager", "cpm-update-package-lock"]
 
 [tool.pylint.main]


### PR DESCRIPTION
We've currently got the `LICENSES/` folder that contains all of the licenses that our current source-code covers.

However, when we distribute a binary wheel, the binary also contains libraries that are statically/dynamically linked, so we also have to list those licenses.

---

@mereacre, @AshleySetter, @johnmanslow, do you want to give a quick review just to confirm that this format of showing all of the licenses is acceptable? Ideally we'd have an @nqminds lawyer look over this, but having five different programmers review it is probably just as okay :)

Both the `LICENSES/` folder and this new `docs/licenses.rst` file will be distributed in the Python binary wheel in the `nqm_irimager-0.1.0a0.dist-info` metadata folder.

By the way, I'm not sure how familiar you guys are with [ReST](https://en.wikipedia.org/wiki/ReStructuredText) instead of Markdown, so here's what the rendered page looks like:

![image](https://github.com/nqminds/nqm-irimager/assets/19716675/f9680ff4-c348-4b67-a82c-c97622164a2e)

