### PR TITLE
ci(build): cache libirimager download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
     types:
       - published
 
+env:
+  libirimager_version: "4.1.1"
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -23,9 +26,30 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Cache libirimager ${{ env.libirimager_version }}
+        id: libirimager-cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ runner.temp }}/libirimager"
+          key: libirimager-${{ env.libirimager_version }}
+
+      - name: Download libirimager ${{ env.libirimager_version }}
+        if: steps.libirimager-cache.outputs.cache-hit != 'true'
+        working-directory: "${{ runner.temp }}"
+        run: |
+          mkdir -p libirimager
+          cd libirimager
+          for ARCH in "amd64"; do
+            wget "http://ftp.evocortex.com/libirimager-4.1.1-${ARCH}.deb"
+          done
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.14.1
         env:
+          # in cibuildwheel environment, the `/host` folder contains the
+          # host file system
+          CIBW_ENVIRONMENT_LINUX: >
+            LIBIRIMAGER_DOWNLOAD_DIR="/host/${{ runner.temp }}/libirimager"
           CIBW_BEFORE_ALL_LINUX: |
             set -e # exit on error
             ARCH="$(uname -m)" # convert the Linux arch to Debian ABI arch
@@ -41,8 +65,7 @@ jobs:
             esac
             dnf install epel-release wget systemd-devel libusb-devel --assumeyes
             dnf install alien --assumeyes
-            wget "http://ftp.evocortex.com/libirimager-4.1.1-${ARCH}.deb"
-            alien --to-rpm "./libirimager-4.1.1-${ARCH}.deb"
+            alien --to-rpm "${LIBIRIMAGER_DOWNLOAD_DIR}/libirimager-4.1.1-${ARCH}.deb"
             # the auto-generated RPM made by alien is kinda buggy, so we need
             # to use --replacefiles to avoid rpm throwing an error
             rpm --install --replacefiles ./libirimager-4.1.1-*.rpm


### PR DESCRIPTION
Cache the `libirimager` download.

This is mainly to avoid DDoS-ing the lirimager download server, since it's not a major service like GitHub or PyPI.

## Implementation details

We can't just use [actions/cache](https://github.com/actions/cache) directly, because the [`cibuildwheel`](https://github.com/pypa/cibuildwheel) doesn't run directly in the GitHub Actions environment. Instead, it runs in a Docker container inside the GitHub Actions environment. Luckily, the Docker container exposes the entire host file-system in the `/host` directory, so we can use this to access the download directory from inside the container.