### PR TITLE
build: use libusb-1.0-0 instead of libusb

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ RUN wget http://ftp.evocortex.com/libirimager-4.1.1-amd64.deb -O /tmp/libirimage
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
         'libudev-dev' \
-        'libusb-dev' \
+        'libusb-1.0-0-dev' \
         'gcc' \
         'pkg-config' \
         'build-essential' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
               i686) ARCH="386";;
               i386) ARCH="386";;
             esac
-            dnf install epel-release wget systemd-devel libusb-devel --assumeyes
+            dnf install epel-release wget systemd-devel libusb1-devel --assumeyes
             dnf install alien --assumeyes
             wget "http://ftp.evocortex.com/libirimager-4.1.1-${ARCH}.deb"
             alien --to-rpm "./libirimager-4.1.1-${ARCH}.deb"

--- a/cmake/FindLibUsb.cmake
+++ b/cmake/FindLibUsb.cmake
@@ -4,7 +4,7 @@
 FindLibUsb
 -----------
 
-Find LibUsb, the Linux userspace USB programming library.
+Find LibUsb-1.0, the Linux userspace USB programming library.
 
 Imported Targets
 ^^^^^^^^^^^^^^^^
@@ -32,10 +32,10 @@ This module will set the following variables in your project:
 cmake_minimum_required(VERSION 3.15...3.26)
 
 find_package(PkgConfig QUIET)
-pkg_check_modules(PC_LibUsb QUIET libusb IMPORTED_TARGET)
+pkg_check_modules(PC_LibUsb QUIET libusb-1.0 IMPORTED_TARGET)
 
-find_path(LibUsb_INCLUDE_DIRS NAMES usb.h HINTS "${PC_LibUsb_INCLUDE_DIRS}")
-find_library(LibUsb_LIBRARIES NAMES usb HINTS "${PC_LibUsb_LIBRARY_DIRS}")
+find_path(LibUsb_INCLUDE_DIRS NAMES libusb-1.0/libusb.h usb.h HINTS "${PC_LibUsb_INCLUDE_DIRS}")
+find_library(LibUsb_LIBRARIES NAMES usb-1.0 HINTS "${PC_LibUsb_LIBRARY_DIRS}")
 
 set(LibUsb_VERSION "${PC_LibUsb_VERSION}")
 


### PR DESCRIPTION
`libirimager` does not work with `libusb`. Instead, it specifically needs `libusb-1.0-0` to work.

## Ubuntu packages

- `libusb-dev`: https://packages.ubuntu.com/jammy/amd64/libusb-dev
  - Contains `v0.1.12` of the libusb library (not compatible with `libirimager`)
- `libusb-1.0-0-dev`: https://packages.ubuntu.com/jammy/libusb-1.0-0-dev
  - Contains `v1.0.25` of the libusb library (compatible with `libirimager`)

## AlmaLinux 8 (used for `manylinux-2-28` build) packages

- `libusb-devel`: https://almalinux.pkgs.org/8/almalinux-powertools-aarch64/libusb-devel-0.1.5-12.el8.aarch64.rpm.html
  - Contains `v0.1.5` of the libusb library (not compatible with `libirimager`)
- `libusb1-devel` (matches `libusbx-devel`): https://almalinux.pkgs.org/8/almalinux-baseos-x86_64/libusbx-devel-1.0.23-4.el8.x86_64.rpm.html
  - Contains `v1.0.23` of the libusb library (compatible with `libirimager`)
