### PR TITLE
build: use `spdlog_header_only` library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,11 @@ set_target_properties(irimager PROPERTIES
     "src/nqm/irimager/irimager_class.hpp;${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
   CXX_VISIBILITY_PRESET "hidden"
 )
-target_link_libraries(irimager PRIVATE pybind11::headers spdlog::spdlog)
+target_link_libraries(irimager
+  PRIVATE
+    pybind11::headers
+    spdlog::spdlog_header_only # less efficient, but avoids CXX11 ABI issues
+)
 
 if(NOT IRImager_mock)
   find_package(IRImager)


### PR DESCRIPTION
Use the `spdlog::spdlog_header_only` CMake target instead of `spdlog::spdlog`.

This is slightly slower (since it recompiles all of the headers every time), but it means we don't need to worry about CXX11 ABI issues.
