### PR TITLE
build: use `pybind11_add_module()` helper function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,16 +71,14 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
 )
 
-python_add_library(irimager MODULE
+pybind11_add_module(irimager MODULE
   "src/nqm/irimager/irimager.cpp"
   "$<IF:$<BOOL:${IRImager_mock}>,src/nqm/irimager/irimager_mock.cpp,src/nqm/irimager/irimager_class.cpp>"
   "${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
-  WITH_SOABI
 )
 set_target_properties(irimager PROPERTIES
   PRIVATE_HEADER
     "src/nqm/irimager/irimager_class.hpp;${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
-  CXX_VISIBILITY_PRESET "hidden"
 )
 target_link_libraries(irimager PRIVATE pybind11::headers spdlog::spdlog)
 


### PR DESCRIPTION
Use the [`pybind11_add_module()`][1] function that is exported as part of pybind11's CMake config.

This allows us to get rid of some custom code, like manually setting [`CXX_VISIBILITY_PRESET hidden`][2] or setting `WITH_SOABI`.

[1]: https://pybind11.readthedocs.io/en/stable/cmake/index.html#pybind11-add-module
[2]: https://github.com/nqminds/nqm-irimager/commit/0b6edd8d976b8e806b962f50ba7366610111964f