### PR TITLE
Add licensing/copyright information for CPM

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,3 +1,4 @@
+Copyright (c) 2019-2022 Lars Melchior and contributors
 Copyright (c) 2017 Michael Graham Johnson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2022 Lars Melchior and contributors
+
 set(CPM_DOWNLOAD_VERSION 0.38.2)
 
 if(CPM_SOURCE_CACHE)


### PR DESCRIPTION
This is pretty minor, but in order to comply with CPM's MIT license, we need to add CPM's copyright text in our source-code, see https://github.com/cpm-cmake/CPM.cmake/blob/master/LICENSE

