### PR TITLE
style: run black on `tests/test_version`

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,9 +9,12 @@ else:
 
 import nqm.irimager
 
+
 def test_version():
     """Test whether the PEP 396 __version__ attribute is correctly set"""
-    with (pathlib.Path(__file__).parent.parent / "pyproject.toml").open("rb") as pyproject_file:
+    with (pathlib.Path(__file__).parent.parent / "pyproject.toml").open(
+        "rb"
+    ) as pyproject_file:
         data = tomllib.load(pyproject_file)
     expected_version = data["project"]["version"]
     actual_version = nqm.irimager.__version__


### PR DESCRIPTION
These changes were auto-generated with `pdm run pre-commit run --all`.

I'm not sure why `pre-commit` didn't catch this issue, maybe it's because this file was made before we added the `pre-commit` config, and `pre-commit` only checks changes by default? _Edit: CI will catch this error in PR #40._