### PR TITLE
ci(test): run `pre-commit` on all files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           # SKIP `no-commit-to-branch`, otherwise CI on `main` will fail,
           # see https://github.com/pre-commit/pre-commit-hooks/issues/265
           SKIP: "no-commit-to-branch"
-        run: pdm run pre-commit run --show-diff-on-failure --color=always
+        run: pdm run pre-commit run --all --show-diff-on-failure --color=always
       - name: Check whether nqm.irimager stubs match implementation
         env:
           MYPYPATH: src


### PR DESCRIPTION
:facepalm: I'm an idiot. The pre-commit checks in our GitHub Action weren't actually running, since we didn't have the `--all` flag.

This was fixed last month in the `python-template` repo in PR https://github.com/nqminds/python-template/pull/5.