### PR TITLE
fix: add include guard to `irimager_class.hpp`

### DIFF
--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -1,3 +1,6 @@
+#ifndef NQM_IRIMAGER_IRIMAGER
+#define NQM_IRIMAGER_IRIMAGER
+
 #include <pybind11/numpy.h>
 
 #include <chrono>
@@ -110,3 +113,5 @@ class IRImagerMock : public IRImager {
  public:
   IRImagerMock(const std::filesystem::path &xml_path);
 };
+
+#endif /* NQM_IRIMAGER_IRIMAGER */


### PR DESCRIPTION
I've just noticed I forgot to add an [include guard](https://en.wikipedia.org/wiki/Include_guard) to our header file :facepalm:. I'm surprised nothing warned us about it, but here it is anyway.

