### PR TITLE
ci(build): handle PDM v2.9.0 change in API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: pipx install pdm
       - name: Install cibuildwheel
         run: |
-          pdm install --group cibuildwheel --no-default
+          pdm install --group cibuildwheel --no-default --no-self
       - id: set-matrix
         run: |
             echo "include=$(
@@ -73,7 +73,7 @@ jobs:
         run: pipx install pdm
       - name: Install cibuildwheel
         run: |
-          pdm install --group cibuildwheel --no-default
+          pdm install --group cibuildwheel --no-default --no-self
       - name: Build wheels
         run: |
           pdm run cibuildwheel --only '${{ matrix.only }}'


### PR DESCRIPTION
PDM v2.9.0 changed how the `pdm install --no-default` command worked, as it now installs dev dependencies, and it runs a [PEP 517][] build. This means that our CI is now failing, see https://github.com/nqminds/nqm-irimager/actions/runs/6072678770/job/16473094068 for an example.

In order to get the old behaviour, where it only installs dev dependencies (without the build), we now need to add a `--no-self` option.

[PEP 517]: https://peps.python.org/pep-0517/

See PDM bug report: https://github.com/pdm-project/pdm/issues/2230