### PR TITLE
ci: add `--verbose` to all `pdm install` commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: pipx install pdm
       - name: Install cibuildwheel
         run: |
-          pdm install --group cibuildwheel --no-default --no-self
+          pdm install --group cibuildwheel --no-default --no-self --verbose
       - id: set-matrix
         run: |
             echo "include=$(
@@ -73,7 +73,7 @@ jobs:
         run: pipx install pdm
       - name: Install cibuildwheel
         run: |
-          pdm install --group cibuildwheel --no-default --no-self
+          pdm install --group cibuildwheel --no-default --no-self --verbose
       - name: Build wheels
         run: |
           pdm run cibuildwheel --only '${{ matrix.only }}'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cpm-
       - name: pdm install, using mock libirimager library
-        run: pdm install
+        run: pdm install --verbose
         env:
           SKBUILD_CMAKE_ARGS: "-DIRImager_mock=ON"
           CPM_SOURCE_CACHE: ~/.cache/cpm-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cpm-
       - name: pdm install, using mock libirimager library
-        run: pdm install
+        run: pdm install --verbose
         env:
           SKBUILD_CMAKE_ARGS: "-DIRImager_mock=ON"
           CPM_SOURCE_CACHE: ~/.cache/cpm-cache


### PR DESCRIPTION
When the `pdm install` step fails for any reason, it's impossible to view these logs in GitHub Actions, since they are stored into a temporary file that is no longer accessible after the run is completed.

Using [`pdm install`'s `--verbose` option][1] fixes this issue. We could also use `-vv` for even more detailed logs, but it's probably overkill and will just slow down our GitHub Actions.

[1]: https://pdm.fming.dev/latest/reference/cli/#install

### Notes to reviewer

FYI, I used this change to help debug why CI was failing, and it helped me debug and fix it in PR https://github.com/nqminds/nqm-irimager/pull/42.