### PR TITLE
Compile everything with C++17 using cmake `CMAKE_CXX_STANDARD`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ project(
   VERSION "${skbuild_project_numeric_version}"
   LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17) # we use C++17 std::string_view
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # CMake Package Manager
@@ -104,7 +107,6 @@ else()
   target_link_libraries(irimager PRIVATE IRImager::IRImager)
 endif(IRImager_mock)
 
-target_compile_features(irimager PRIVATE cxx_std_17)
 target_compile_definitions(irimager PRIVATE
   DOCSTRINGS_H="${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
   SKBUILD_PROJECT_VERSION="${SKBUILD_PROJECT_VERSION}"


### PR DESCRIPTION
Use [`CMAKE_CXX_STANDARD`][1] to require C++17 for all CMake targets, instead of opting in to C++17 for individual targets with [`target_compile_features`][2].

Some libraries (e.g. spdlog and GoogleTest), use C++ standard libraries backports (e.g. using [`abseil`][3]), so compiling these dependencies under different C++ versions may result in some code using `absl::string_view` instead of `std::string_view`.

[1]: https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html
[2]: https://cmake.org/cmake/help/latest/command/target_compile_features.html
[3]: https://abseil.io/

### Notes to reviewers

This has no effect when running on Ubuntu 22.04, since the default version of GCC on Ubuntu 22.04 (11.4.0) already compiles everything by default in C++17 mode.

However, it makes a big difference when compiling on NVIDIA Jetson Linux 35 and/or Ubuntu 20.04, as it has GCC 9.3.0, which defaults to C++14.