### PR TITLE
Throw an error if the XML config file does not exist

### DIFF
--- a/src/nqm/irimager/irimager_class.cpp
+++ b/src/nqm/irimager/irimager_class.cpp
@@ -8,6 +8,16 @@ struct IRImager::impl {
   impl(const std::filesystem::path &xml_path) {
     // do a basic check that the given file is readable, and is an XML file
     auto xml_stream = std::ifstream(xml_path, std::fstream::in);
+
+    try {
+      xml_stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    } catch (const std::ios_base::failure &error) {
+      // std::ios_base::failure isn't a std::runtime_error,
+      // if we're compiling with _GLIBCXX_USE_CXX11_ABI=0
+      throw std::runtime_error(std::string("Failed to open file ") +
+                               xml_path.string() + " due to " + error.what());
+    }
+
     auto xml_header = std::string(5, '\0');
 
     xml_stream.read(xml_header.data(),

--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -28,6 +28,8 @@ class IRImager {
 
   /**
    * Loads the configuration for an IR Camera from the given XML file
+   *
+   * @throw std::runtime_error if the XML file could not be read.
    */
   IRImager(const std::filesystem::path &xml_path);
 

--- a/tests/test_irimager.py
+++ b/tests/test_irimager.py
@@ -8,6 +8,7 @@ import pytest
 from nqm.irimager import IRImagerMock as IRImager
 
 XML_FILE = pathlib.Path(__file__).parent / "__fixtures__" / "382x288@27Hz.xml"
+README_FILE = pathlib.Path(__file__).parent.parent / "README.md"
 
 
 def test_irimager_loads_xml():
@@ -16,7 +17,10 @@ def test_irimager_loads_xml():
     IRImager(XML_FILE)
 
     with pytest.raises(RuntimeError, match="Invalid XML file"):
-        IRImager(pathlib.Path("README.md"))
+        IRImager(pathlib.Path(README_FILE))
+
+    with pytest.raises(RuntimeError, match="Failed to open file"):
+        IRImager(pathlib.Path("this-file-does-not-exist"))
 
 
 def test_get_frame_fails_when_not_streaming():

--- a/tests/test_irimager_class.cpp
+++ b/tests/test_irimager_class.cpp
@@ -13,6 +13,15 @@ TEST(test_get_temp_range_decimal, BasicAssertions) {
             0);  // this value should almost always be 1
 }
 
+/**
+ * Should throw an error when trying to open a non-existant XML file.
+ */
+TEST(test_irimager_class, NonExistantFile) {
+  auto path = std::filesystem::path("this-file-should-not-exist");
+  EXPECT_THROW(IRImager(path.string().data(), path.string().size()),
+               std::runtime_error);
+}
+
 int main(int argc, char **argv) {
   XML_FILE = std::filesystem::path(argv[0]).parent_path() / "__fixtures__" /
              "382x288@27Hz.xml";


### PR DESCRIPTION
**Blocked by the following PRs:**
  - https://github.com/nqminds/nqm-irimager/pull/45

Throw an `std::runtime_error` if the given XML config file passed to the IRImager class does not exist.

Currently, reading from a non-existent file works, we just get 0-length data, which is pretty confusing (and might actually be undefined behavior according to the C++ standard).

Unfortunately, we can't just throw or re-throw an [`std::ios_base::failure`][1] exception, because even though we're using C++17, we are still using the old `_GLIBCXX_USE_CXX11_ABI=0` pre-C++11 libstdc++ ABI, therefore [`std::io_base::failure` might not an `std::runtime_error`][2]. This means we won't be able to see the actual OS error-code that explains why the file could not be opened.

[1]: https://en.cppreference.com/w/cpp/io/ios_base/failure
[2]: https://github.com/gcc-mirror/gcc/blob/00d16a269a9398b72b9dc9b487bbf7fecd61ffd6/libstdc%2B%2B-v3/include/bits/ios_base.h#L262-L264
