### PR TITLE
Fail dev-container CI job immediately if the `pdm install` step fails. 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,6 @@ jobs:
           # only push new image if this is a on the `main` branch
           refFilterForPush: "refs/heads/main"
           runCmd: |
-            set -e # quit on error
+            set -xe # print cmds, and quit on error
             pdm install
             pdm run pytest


### PR DESCRIPTION
Currently, if the `pdm install` step in the `dev-container` job fails, it's ignored, because that's just how Bash/POSIX scripts work.

For an example, see https://github.com/nqminds/nqm-irimager/actions/runs/6222114563/job/16885403906.

Adding the `set -e` flag fixes this, but causing any failing command to fail the script.

This should save us a couple of GitHub Actions credits!

---

I've also enabled the `-x` shell option (also known as `-o xtrace`), which prints a trace of all the shell commands, before running them.

This flag is set by default when running on GitHub Actions, but since this script is running within a Docker image, we need to set it ourselves.

[1]: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
