### PR TITLE
test: use `pytest-timeout` to stop stuck tests

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "test", "lint", "types", "docs", "cibuildwheel"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:3a45fa5b48e41e847b0ff95296d26adf4dfae10bee29650274a0678e9dcb3a80"
+content_hash = "sha256:c4794bd74a4c7251ae6b7c0d4f8c007d5fcaa703513c3b66e7d3c7e7680e3492"
 
 [[package]]
 name = "alabaster"
@@ -685,6 +685,19 @@ dependencies = [
 files = [
     {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
     {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.1.0"
+requires_python = ">=3.6"
+summary = "pytest plugin to abort hanging tests"
+dependencies = [
+    "pytest>=5.0.0",
+]
+files = [
+    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
+    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ mypy_path = "src"
 addopts = [
     "--import-mode=importlib",
 ]
+timeout = 10 # each test should finish within 5 seconds
 
 [tool.pdm.dev-dependencies]
 lint = [
@@ -67,6 +68,7 @@ test = [
     "pytest>=7.4.0",
     # in Python 3.11+, we can use the built-in tomllib instead
     "tomli<3.0.0,>=2.0.1; python_version < \"3.11\"",
+    "pytest-timeout>=2.1.0, <3.0.0",
 ]
 docs = [
     "sphinx>=5.3.0",
@@ -84,7 +86,10 @@ archs = [
     "x86_64",
 ]
 test-command = "pytest {project}/tests"
-test-requires = "pytest"
+test-requires = [
+    "pytest",
+    "pytest-timeout",
+]
 
 # libirimager needs a relatively new stdc++ library
 manylinux-x86_64-image = "manylinux_2_28"


### PR DESCRIPTION
Use the [`pytest-timeout` package][1] to automatically timeout pytest test cases.

Currently, we're relying on the [`jobs.<job_id>.timeout-minutes`][2] field in our GitHub Actions CI job to handle timing out tests. That has some issues, though:

1. It doesn't let pytest log anything, so we can't see which test failed, or any log messages.
2. It only works in CI (it doesn't work when testing locally)
3. Because the timeout is for the entire job (which takes an extremely variables amount of time), the timeout value is very large.

Switching to `pytest-timeout` fixes all of the above issues. All of our individual tests normally finish within 5 seconds, so we can set a 10 second timeout to spot any errors almost instantly.

### What happens when it triggers

By the way, I've made a new commit called https://github.com/nqminds/nqm-irimager/commit/371f1864c626c804f8cd8bc9369892301858c93c that purposely fails a test by running `import time; time.sleep(30)` and it works! See: https://github.com/nqminds/nqm-irimager/actions/runs/6274119248/job/17038925148

```
  platform linux -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
  rootdir: /project
  configfile: pyproject.toml
  plugins: timeout-2.1.0
  timeout: 10.0s
  timeout method: signal
  timeout func_only: False
  collected 9 items
  
  ../../../project/tests/test_irimager.py .......                          [ 77%]
  ../../../project/tests/test_version.py .F                                [100%]
  
  =================================== FAILURES ===================================
  ________________ test_whether_github_actions_timeouts_x_seconds ________________
  
      def test_whether_github_actions_timeouts_x_seconds():
          """This test should fail, due to our pytest-timeout rule"""
          import time, logging
          print("this is a message on stdout")
          print("this is a message on stderr", file=sys.stderr)
          logging.warning('this is a message on logger!')
  >       time.sleep(30)
  E       Failed: Timeout >10.0s
  
  /project/tests/test_version.py:30: Failed
  ----------------------------- Captured stdout call -----------------------------
  this is a message on stdout
  ----------------------------- Captured stderr call -----------------------------
  this is a message on stderr
  ------------------------------ Captured log call -------------------------------
  WARNING  root:test_version.py:29 this is a message on logger!
  =========================== short test summary info ============================
  FAILED ../../../project/tests/test_version.py::test_whether_github_actions_timeouts_x_seconds
  ========================= 1 failed, 8 passed in 10.18s =========================
```

[1]: https://github.com/pytest-dev/pytest-timeout
[2]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

### Notes to reviewers

This doesn't stop https://github.com/nqminds/nqm-irimager/issues/51, but it should:

- prevent any extraneous GitHub Actions credits from being used (other than wasting a few seconds)
- actually give us proper logs so we can see which tests fail