### PR TITLE
ci: use `SKBUILD_CMAKE_DEFINE` for IRImager_mock

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: pdm install, using mock libirimager library
         run: pdm install --verbose
         env:
-          SKBUILD_CMAKE_ARGS: "-DIRImager_mock=ON"
+          SKBUILD_CMAKE_DEFINE: "IRImager_mock=ON"
           CPM_SOURCE_CACHE: ~/.cache/cpm-cache
       - name: Build documentation into `build/` folder
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,7 @@ jobs:
       - name: pdm install, using mock libirimager library
         run: pdm install --verbose
         env:
-          SKBUILD_CMAKE_ARGS: "-DIRImager_mock=ON"
-          SKBUILD_CMAKE_DEFINE: "BUILD_TESTING=ON"
+          SKBUILD_CMAKE_DEFINE: "BUILD_TESTING=ON;IRImager_mock=ON"
           CPM_SOURCE_CACHE: ~/.cache/cpm-cache
           SKBUILD_CMAKE_BUILD_TYPE: "Debug" # makes compiler warnings into errors
       - uses: actions/cache@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
   if(NOT IRImager_FOUND)
     message(FATAL_ERROR "libirimager was not found. \
       It can be downloaded from https://evocortex.org/products/irimagerdirect-sdk/. \
-      Alternatively, compile with `SKBUILD_CMAKE_ARGS='-DIRImager_mock=ON'` to
+      Alternatively, compile with `SKBUILD_CMAKE_DEFINE='IRImager_mock=ON'` to
       create a mocked extension \
       that doesn't need libirimager, or a thermal camera.")
   endif()

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Python module for interfacing with [EvoCortex IRImagerDirect SDK][1].
 install the package.
 
 It's possible to install a mocked version of `nqm.irimager` for testing
-by defining `SKBUILD_CMAKE_ARGS='-DIRImager_mock=ON'` whiling building
+by defining `SKBUILD_CMAKE_DEFINE='IRImager_mock=ON'` whiling building
 `nqm.irimager`.
 
 ### Install `nqm.irimager`
@@ -63,6 +63,12 @@ and running these tests by using:
 
 ```bash
 SKBUILD_CMAKE_DEFINE="BUILD_TESTING=ON" pdm install && pdm run pytest
+```
+
+If you want to use both `BUILD_TESTING=ON` and `IRImager_mock=ON`, you can do the following:
+
+```bash
+SKBUILD_CMAKE_DEFINE='BUILD_TESTING=ON;IRImager_mock=ON' pdm install && pdm run pytest
 ```
 
 #### Mypy stubtest


### PR DESCRIPTION
Use the `SKBUILD_CMAKE_DEFINE` environment value for setting the CMake definition for `IRImager_mock=ON`. Currently, we are using `SKBUILD_CMAKE_ARGS` which works, but isn't ideal. 

See https://scikit-build-core.readthedocs.io/en/latest/configuration.html#configuring-cmake-arguments-and-defines