### PR TITLE
test: fix typo in test name

### DIFF
--- a/tests/test_irimager_class.cpp
+++ b/tests/test_irimager_class.cpp
@@ -14,9 +14,9 @@ TEST(test_get_temp_range_decimal, BasicAssertions) {
 }
 
 /**
- * Should throw an error when trying to open a non-existant XML file.
+ * Should throw an error when trying to open a non-existent XML file.
  */
-TEST(test_irimager_class, NonExistantFile) {
+TEST(test_irimager_class, NonExistentFile) {
   auto path = std::filesystem::path("this-file-should-not-exist");
   EXPECT_THROW(IRImager(path.string().data(), path.string().size()),
                std::runtime_error);


### PR DESCRIPTION
Fixes a minor typo in a test name. I know it's super minor, but it's worth fixing anyway, since we might use it in the CLI to filter tests, e.g. `pytest -k NonExistentFile`.