### PR TITLE
fix: remove GIL requirement in most IRImager funcs

### DIFF
--- a/src/nqm/irimager/irimager.cpp
+++ b/src/nqm/irimager/irimager.cpp
@@ -26,33 +26,38 @@ to control these cameras.)";
 
   m.attr("__version__") = SKBUILD_PROJECT_VERSION;
 
+  // helps prevent deadlock when calling code that doesn't touch Python objs
+  const auto no_gil = pybind11::call_guard<pybind11::gil_scoped_release>();
+
   pybind11::class_<IRImager>(m, "IRImager", DOC(IRImager))
       .def(pybind11::init<const std::filesystem::path &>(),
-           DOC(IRImager, IRImager))
-      .def("get_frame", &IRImager::get_frame, DOC(IRImager, get_frame))
+           DOC(IRImager, IRImager), no_gil)
+      .def("get_frame", &IRImager::get_frame,
+           DOC(IRImager, get_frame))  // get_frame needs GIL
       .def("get_temp_range_decimal", &IRImager::get_temp_range_decimal,
-           DOC(IRImager, get_temp_range_decimal))
+           DOC(IRImager, get_temp_range_decimal), no_gil)
       .def("get_library_version", &IRImager::get_library_version,
-           DOC(IRImager, get_library_version))
+           DOC(IRImager, get_library_version), no_gil)
       .def("start_streaming", &IRImager::start_streaming,
-           DOC(IRImager, start_streaming))
+           DOC(IRImager, start_streaming), no_gil)
       .def("stop_streaming", &IRImager::stop_streaming,
-           DOC(IRImager, stop_streaming))
+           DOC(IRImager, stop_streaming), no_gil)
       .def("__enter__", &IRImager::_enter_,
-           pybind11::return_value_policy::reference_internal)
+           pybind11::return_value_policy::reference_internal, no_gil)
       .def("__exit__", &IRImager::_exit_);
 
   pybind11::class_<IRImagerMock, IRImager>(m, "IRImagerMock", DOC(IRImagerMock))
       .def(pybind11::init<const std::filesystem::path &>(),
-           DOC(IRImager, IRImager))
-      .def("get_frame", &IRImagerMock::get_frame, DOC(IRImager, get_frame))
+           DOC(IRImager, IRImager), no_gil)
+      .def("get_frame", &IRImagerMock::get_frame,
+           DOC(IRImager, get_frame))  // get_frame needs GIL
       .def("get_temp_range_decimal", &IRImagerMock::get_temp_range_decimal,
-           DOC(IRImager, get_temp_range_decimal))
+           DOC(IRImager, get_temp_range_decimal), no_gil)
       .def("start_streaming", &IRImagerMock::start_streaming,
-           DOC(IRImager, start_streaming))
+           DOC(IRImager, start_streaming), no_gil)
       .def("stop_streaming", &IRImagerMock::stop_streaming,
-           DOC(IRImager, stop_streaming))
+           DOC(IRImager, stop_streaming), no_gil)
       .def("__enter__", &IRImagerMock::_enter_,
-           pybind11::return_value_policy::reference_internal)
+           pybind11::return_value_policy::reference_internal, no_gil)
       .def("__exit__", &IRImagerMock::_exit_);
 }


### PR DESCRIPTION
Disable the [GIL][] (CPython's global interpreter lock) for most IRImager functions, with the exception of:
  - `get_frame()` (as it creates a `pybind11::array_t`)
  - `__exit__()` (as it accepts `pybind11::object`s as arguments)

I'm not 100% sure why, but removing the GIL from these functions seems to avoid some of the deadlocks that was rarely causing https://github.com/nqminds/nqm-irimager/issues/51.

[GIL]: https://docs.python.org/3/glossary.html#term-global-interpreter-lock