### PR TITLE
style: fix sorting `#include <spdlog/fmt/*.h>`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,4 +3,10 @@ Language: Cpp
 BasedOnStyle: Google
 IndentWidth: 2
 ColumnLimit: 80
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^<spdlog/fmt/.*\.h>' # spdlog/spdlog.h must be included first
+    SortPriority: 3
+  - Regex: '^<spdlog/.*\.h>'
+    SortPriority: 2
 ...


### PR DESCRIPTION
Clang-format sorts our includes alphabetically.
However, spdlog requires that the `#include <spdlog/spdlog.h>` header is included before `#include <spdlog/fmt/*.h>`, if using the CMake `spdlog::spdlog_header_only` target.

We can use the [`IncludeCategories`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#includecategories) `clang-format` option to tell Clang to prioritize including `^<spdlog/.*\.h>'` over `^<spdlog/fmt/.*\.h>`

---

For example, the following will fail to compile during the link stage:

```c++
#include <spdlog/fmt/chrono.h>
#include <spdlog/spdlog.h>
```

with a bunch of errors like:

```
pdm.termui: /usr/bin/ld: tests/CMakeFiles/test_chrono.dir/test_chrono.cpp.o: in function `unsigned long long fmt::v9::detail::precision_checker<fmt::v9::detail::error_handler>::operator()<long double, 0>(long double) [clone .isra.0]':
pdm.termui: test_chrono.cpp:(.text+0x2e): undefined reference to `fmt::v9::detail::throw_format_error(char const*)'
```