### PR TITLE
chore: add `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# commits to ignore from `git blame`
+
+# style: format C++ code through clang-format
+363ce1d69fe0e2d3dd978f1d5a82010d8e69d39f
+# style: fix indentation in `irimager_class.cpp`
+22cd3262bc53484b92d544901753e6c8f543e79d


### PR DESCRIPTION
Add a `.git-blame-ignore-revs` file, used by GitHub to ignore commits when doing a `git blame`, see
https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

It can also be used with the git CLI, by doing [`git blame --ignore-revs-file`][1], or using the `blame.ignoreRevsFile` git option.

The commits ignored are:
 - 363ce1d (style: format C++ code through clang-format, 2023-08-21)
 - 22cd326 (style: fix indentation in `irimager_class.cpp`, 2023-08-14)

[1]: https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt

---

For example, looking at https://github.com/nqminds/nqm-irimager/blame/c2d8562039deb3d67d72aa91dcb2d38793e048db/src/nqm/irimager/irimager_class.cpp is pretty difficult currently, since these `style: xxx` commits are hiding the actual important changes.

It's pretty minor, but I found myself doing `git blame --ignore-rev 363ce1d69fe0e2d3dd978f1d5a82010d8e69d39f` a couple of times, so I thought I might as well save this into a file to save time in the future. It's probably much more useful in bigger projects where we have a lot of different auto-formatting changes.