### PR TITLE
fix: use IRImager::impl::get_temp_range_decimal()

### DIFF
--- a/src/nqm/irimager/irimager_class.cpp
+++ b/src/nqm/irimager/irimager_class.cpp
@@ -154,7 +154,9 @@ IRImager::get_frame() {
   return pImpl->get_frame();
 }
 
-short IRImager::get_temp_range_decimal() { return 1; }
+short IRImager::get_temp_range_decimal() {
+  return pImpl->get_temp_range_decimal();
+}
 
 std::string_view IRImager::get_library_version() {
   return pImpl->get_library_version();


### PR DESCRIPTION
In 4fc69b5fa8d1205b52affcb62dc36c756042ee5a, we changed all the `IRImager::x()` methods to call `pImpl->x()`, where `pImpl` was a pointer to either a `IRImagerRealImpl` or a `IRImagerMockImpl`, depending on whether we are using a real camera or a mocked camera.

But it turns out, I forgot to update the `IRImager::get_temp_range_decimal()` function to call `IRImager::impl::get_temp_range_decimal()`.

I'm surprised that we didn't get an `-Wunused-function` warning warning us that `IRImager::impl::get_temp_range_decimal()` was never used, but maybe all the different `virtual` functions confused the compiler.

Fixes: 4fc69b5fa8d1205b52affcb62dc36c756042ee5a