### PR TITLE
fix: use `gnu::access` attribute only on GCC

### DIFF
--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -41,8 +41,14 @@ class IRImager {
    * if possible. This function only exists to work-around C++11 libstdc++
    * ABI issues.
    */
-  [[gnu::access(read_only, 2, 3),
-    gnu::nonnull(2)]] IRImager(const char *xml_path, std::size_t xml_path_len);
+  [[
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(gnu::access)
+      gnu::access(read_only, 2, 3),
+#endif
+#endif
+      gnu::nonnull(2)]] IRImager(const char *xml_path,
+                                 std::size_t xml_path_len);
 
   /** Destructor */
   virtual ~IRImager();
@@ -134,9 +140,14 @@ class IRImagerMock : public IRImager {
    * if possible. This function only exists to work-around C++11 libstdc++
    * ABI issues.
    */
-  [[gnu::access(read_only, 2, 3),
-    gnu::nonnull(2)]] IRImagerMock(const char *xml_path,
-                                   std::size_t xml_path_len);
+  [[
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(gnu::access)
+      gnu::access(read_only, 2, 3),
+#endif
+#endif
+      gnu::nonnull(2)]] IRImagerMock(const char *xml_path,
+                                     std::size_t xml_path_len);
 };
 
 #endif /* NQM_IRIMAGER_IRIMAGER */


### PR DESCRIPTION
Only use the `[[gnu::access]]` attribute on compilers that support it, i.e. GCC.

This fixes a few `-Wattribute` warnings/errors on Clang.

### Implementation details

The `__has_cpp_attribute()` macro expands to a non-zero value if the given attribute is supported by the compiler, see https://en.cppreference.com/w/cpp/feature_test.

This gives us an easy way to test whether `gnu::access` is supported on a given compiler.

However, `__has_cpp_attribute()` is only added by C++20 and we need to be able to compile with C++17! Luckily, GCC v9 added support for `__has_cpp_attribute()`, even when compiling for C++17 mode, so we can still use it. I've stuck an `#ifdef __has_cpp_attribute` first so if other compilers don't support `__has_cpp_attribute()` in C++17 mode, it's still fine.

This is also how GCC recommends using the similar [`__has_attribute()` macro](https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html#g_t_005f_005fhas_005fattribute-1).