### PR TITLE
ci(test): test building using Clang

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
+        cxx: ["g++", "clang++"]
     steps:
       - uses: actions/checkout@v3
       - name: Install pdm
@@ -30,6 +31,7 @@ jobs:
           SKBUILD_CMAKE_DEFINE: "BUILD_TESTING=ON;IRImager_mock=ON"
           CPM_SOURCE_CACHE: ~/.cache/cpm-cache
           SKBUILD_CMAKE_BUILD_TYPE: "Debug" # makes compiler warnings into errors
+          CXX: ${{ matrix.cxx }}
       - uses: actions/cache@v3
         name: Cache pre-commit
         with:


### PR DESCRIPTION
Try compiling this module with [Clang](https://clang.llvm.org) in GitHub Actions CI.

This is mainly to make sure that bugs like #62 don't occur again.

The Clang compiler also checks for a bunch of separate errors/warnings that GCC doesn't check for, so running both is pretty useful. For example, Clang noticed a symbol/linker issue that just happened to work in my WIP `feat/add-irimager` branch.

The main downside is that this uses up more CI time, but considering that this additional build for Clang only takes 1 minute 30 seconds, that's only $0.016 USD, so it's worth it. And if we open-source this repo in the future, it will become completely free.

---

Side-note, it would also be pretty nice to have Clang compile an arm64 version of the code, since there are occasionally differences between different architectures (e.g. tail-call optimization is apparently more difficult on MIPS?), but it's probably not worth the extra GitHub Actions CI credits usage, since arm64 is pretty similar to x86_64.