### PR TITLE
docs: sync get_temp_range_decimal() pyi docs

### DIFF
--- a/src/nqm/irimager/__init__.pyi
+++ b/src/nqm/irimager/__init__.pyi
@@ -57,10 +57,10 @@ class IRImager:
     def get_temp_range_decimal(self) -> int:
         """The number of decimal places in the thermal data
 
-        For example, if :py:meth:`~IRImager.get_frame` returns 18000, you can
+        For example, if :py:meth:`~IRImager.get_frame` returns 19000, you can
         divide this number by 10 to the power of the result of
-        :py:meth:`~IRImager.get_temp_range_decimal` to get the actual
-        temperature in degrees Celcius.
+        :py:meth:`~IRImager.get_temp_range_decimal`, then subtract 100,
+        to get the actual temperature in degrees Celcius.
         """
     def get_library_version(self) -> typing.Union[str, typing.Literal["MOCKED"]]:
         """Get the version of the libirimager library.


### PR DESCRIPTION
Sync the docstring for `get_temp_range_decimal()` in the `.pyi` stubfile with the real docstring (e.g. what's returned by running `help(get_temp_range_decimal)` in Python).

Fixes: 2123685d4b7a38b79adeb01b5195813c5170291a (where I accidentally updated the docs in only one place)

---

Unfortunately, [`stubtest`](https://mypy.readthedocs.io/en/stable/stubtest.html) only seems to check types, not the docstrings, so I'm not sure if there's an automated way to check whether I've forgotten to manually update these docstrings.