### PR TITLE
Create `StringRingBuffer` C++ class

### DIFF
--- a/src/nqm/irimager/string_ring_buffer.hpp
+++ b/src/nqm/irimager/string_ring_buffer.hpp
@@ -1,0 +1,137 @@
+/**
+ * @file
+ * @author Alois Klink <alois@nquiringminds.com>
+ * @brief Ring buffer designed for string data.
+ *
+ * @copyright
+ * SPDX-FileCopyrightText: © 2023 NquiringMinds Ltd.
+ */
+
+#ifndef NQM_IRIMAGER_STRING_RING_BUFFER
+#define NQM_IRIMAGER_STRING_RING_BUFFER
+
+#include <array>
+#include <string>
+#include <string_view>
+
+/**
+ * @brief FIFO Ring buffer for string data.
+ *
+ * @warning This class is not thread safe.
+ *
+ * @tparam N The size of the string buffer (allocated on the stack).
+ *           For performance reasons, please pick a power of 2 (2ⁿ).
+ */
+template <std::size_t N>
+class StringRingBuffer {
+ public:
+  /**
+   * Returns the number of characters in the buffer.
+   */
+  size_t size() { return _size; }
+
+  /**
+   * @brief Insert the string into the buffer.
+   *
+   * @throws std::out_of_range if there isn't enough space in the buffer
+   *                           for the given string.
+   */
+  void insert(std::string_view string) {
+    if (_size == data.size()) {
+      if (!string.empty()) {
+        throw std::out_of_range("Not enough space in this ring buffer");
+      }
+    } else if (begin <= end()) {
+      std::size_t space_before_overflow =
+          static_cast<std::size_t>(data.size() - end());
+      std::size_t bytes_to_write_to_r =
+          std::min(string.size(), space_before_overflow);
+      string.copy(&data.data()[end()], bytes_to_write_to_r);
+      _size += bytes_to_write_to_r;
+      if (bytes_to_write_to_r != string.size()) {
+        insert(string.substr(bytes_to_write_to_r));
+      }
+    } else {
+      std::size_t space_before_overflow =
+          static_cast<std::size_t>(begin - end());
+      if (string.size() > space_before_overflow) {
+        throw std::out_of_range("Not enough space in this ring buffer");
+      }
+      string.copy(&data.data()[end()], string.size());
+      _size += string.size();
+    }
+  }
+
+  /**
+   * @brief Get the current string in the buffer.
+   */
+  std::string peek() {
+    if (_size == 0) {
+      return "";
+    }
+    if (begin < end()) {
+      return std::string(&data.data()[begin],
+                         static_cast<std::size_t>(end() - begin));
+    } else {
+      return std::string(&data.data()[begin],
+                         static_cast<std::size_t>(data.size() - begin)) +
+             std::string(&data.data()[0], end());
+    }
+  }
+
+  /**
+   * @brief Discard the given number of bytes.
+   *
+   * @throws std::out_of_range if discarding more bytes than are in the
+   *                           buffer.
+   */
+  void discard(std::size_t bytes) {
+    if (bytes > size()) {
+      throw std::out_of_range("Not enough bytes in this ring buffer");
+    }
+
+    if (begin <= end()) {
+      begin += bytes;
+      _size -= bytes;
+
+      if (begin >= data.size()) {
+        begin = 0;
+      }
+    } else {
+      std::size_t space_before_overflow =
+          static_cast<std::size_t>(data.size() - begin);
+      std::size_t bytes_to_discard_now = std::min(bytes, space_before_overflow);
+      _size -= bytes_to_discard_now;
+
+      if (bytes_to_discard_now != bytes) {
+        begin = 0;
+        discard(bytes - bytes_to_discard_now);
+      } else {
+        begin += bytes_to_discard_now;
+      }
+    }
+  }
+
+ private:
+  /**
+   * @brief Index of the first filled data point.
+   *
+   * @warning if @p _size is `0`, then this index has no data and means
+   *          nothing.
+   */
+  std::size_t begin = 0;
+
+  /**
+   * @brief The number characters stored in this ring buffer.
+   */
+  std::size_t _size = 0;
+
+  std::array<char, N> data;
+
+  /**
+   * @brief Index of the first unfilled data point.
+   */
+  std::size_t end() { return (begin + _size) % data.size(); }
+};
+
+#endif /* NQM_IRIMAGER_STRING_RING_BUFFER */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,3 +17,11 @@ target_link_libraries(test_irimager_class
     Python::Python
     irimager_class
 )
+
+add_executable(test_string_ring_buffer
+  test_string_ring_buffer.cpp
+)
+target_link_libraries(test_string_ring_buffer
+  PRIVATE
+    GTest::gtest_main
+)

--- a/tests/test_string_ring_buffer.cpp
+++ b/tests/test_string_ring_buffer.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+
+#include "../src/nqm/irimager/string_ring_buffer.hpp"
+
+// Demonstrate some basic assertions.
+TEST(test_string_ring_buffer, BasicAssertions) {
+  auto abc = StringRingBuffer<16>();
+  EXPECT_EQ(abc.size(), 0);
+
+  EXPECT_EQ(abc.peek(), std::string(""));
+
+  EXPECT_THROW(abc.discard(1), std::out_of_range);
+
+  abc.insert("a");
+  EXPECT_EQ(abc.size(), 1);
+  EXPECT_EQ(abc.peek(), std::string("a"));
+
+  abc.discard(1);
+  EXPECT_EQ(abc.size(), 0);
+  EXPECT_EQ(abc.peek(), std::string(""));
+
+  abc.insert("0123456789abcdef");
+  EXPECT_EQ(abc.size(), 16);
+  EXPECT_EQ(abc.peek(), std::string("0123456789abcdef"));
+
+  abc.discard(1);
+  EXPECT_EQ(abc.size(), 15);
+  EXPECT_EQ(abc.peek(), std::string("123456789abcdef"));
+
+  abc.insert("0");
+  EXPECT_EQ(abc.size(), 16);
+  EXPECT_EQ(abc.peek(), std::string("123456789abcdef0"));
+
+  EXPECT_THROW(abc.insert("1"), std::out_of_range);
+
+  abc.discard(8);
+  abc.insert("ABCDEFGH");
+  EXPECT_EQ(abc.size(), 16);
+  EXPECT_EQ(abc.peek(), std::string("9abcdef0ABCDEFGH"));
+}
+
+// should handle NUL (␀) characters
+TEST(test_string_ring_buffer, HandlesNulChars) {
+  using namespace std::string_literals;
+
+  auto abc = StringRingBuffer<16>();
+
+  // we're not in C-world anymore ␀🧙
+  abc.insert("\0\0\0"s);
+
+  EXPECT_EQ(abc.size(), 3);
+  EXPECT_EQ(abc.peek(), std::string("\0\0\0"s));
+}
+
+// should handle multi-byte characters
+TEST(test_string_ring_buffer, HandlesMultibytesChars) {
+  auto abc = StringRingBuffer<8>();
+
+  abc.insert("🂢");
+  EXPECT_EQ(abc.size(), 4);
+  EXPECT_EQ(abc.peek(), "🂢");
+
+  abc.insert("abc");
+  EXPECT_EQ(abc.size(), 7);
+
+  abc.discard(4);
+  abc.insert("🂢");
+  EXPECT_EQ(abc.size(), 7);
+  // multi-byte character should look fine, even if it straddles the
+  // beginning/end of the circular buffer
+  EXPECT_EQ(abc.peek(), "abc🂢");
+
+  abc.discard(4);
+  EXPECT_EQ(abc.size(), 3);
+  // should show the last three UTF-8 bytes for 🂢
+  EXPECT_EQ(abc.peek(), "\x9f\x82\xa2");
+}
+
+// should work, even with a size that isn't a power of 2
+TEST(test_string_ring_buffer, SupportsAnySize) {
+  auto abc = StringRingBuffer<3>();
+
+  abc.insert("123");
+  EXPECT_EQ(abc.size(), 3);
+  EXPECT_EQ(abc.peek(), std::string("123"));
+
+  abc.discard(1);
+  EXPECT_EQ(abc.size(), 2);
+  EXPECT_EQ(abc.peek(), std::string("23"));
+
+  abc.insert("4");
+  EXPECT_EQ(abc.size(), 3);
+  EXPECT_EQ(abc.peek(), std::string("234"));
+
+  EXPECT_THROW(abc.insert("5"), std::out_of_range);
+
+  EXPECT_THROW(abc.discard(4), std::out_of_range);
+}


### PR DESCRIPTION
**This PR depends on**:
  - #67

Please switch the target branch for this PR to `main` after the above PR has been merged.

---

Add a `StringRingBuffer` C++ class that operates as a [ring/circular buffer](https://en.wikipedia.org/wiki/Circular_buffer) for string data.

### Example Usage

https://github.com/nqminds/nqm-irimager/blob/3bf332ef12889ad4126a7d3419dc5c8ee6d73810/tests/test_string_ring_buffer.cpp#L80-L98

### Why do we need to add this?

I'm trying to parse the log output from the [`evo::IRLogger` class in the IRImagerDirect SDK](http://documentation.evocortex.com/libirimager2/html/classevo_1_1IRLogger.html).

The log output is just a stream of characters, so I need to somehow parse it into lines.

But, I can't use [std::stringstream](https://en.cppreference.com/w/cpp/io/basic_stringstream) because `std::stringstream` uses a linear buffer, and so the longer we have read/write to it, the more and more memory it takes before the program eventually crashes.

Essentially, all I want something similar to the following Node.JS code, but in C++:

```javascript
import {Readable} from 'node:stream';
import {pipeline} from 'node:stream/promises';
import {split} from 'event-stream'; // https://www.npmjs.com/package/event-stream

const inputStream = new Readable();

await Promise.all([
  pipeline(inputStream,
           es.split(), // convert byte stream to lines
           async((line) => {
             // my code here
           }),
  async () => {
    while true {
      inputStream.push("some data");
    }
  },
]);
```

I did a quick search on GitHub for C++ ring/circular buffers, but most of them seemed to be generic and didn't have string-specific helper functions, which I wanted. So I just went ahead and made my own!

### Implementation details

#### Why is this a header-only file?

The IRImagerDirect SDK has some wonky behavior with `libstdc++`, as it uses the pre-C++11 ABI for strings. This means that linking may sometimes not work properly when passing/returning `std::string` or `std::string_view` data to functions.