### PR TITLE
Add `IRLoggerToSpd` C++ class to handle reading/setting up `evo::IRLogger`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,34 @@ set_target_properties(irlogger_parser PROPERTIES
   POSITION_INDEPENDENT_CODE ON # -fPIC
 )
 
+if (UNIX)
+  add_library(irlogger_to_spd OBJECT
+    "src/nqm/irimager/irlogger_to_spd_posix.cpp"
+  )
+else()
+  message(FATAL_ERROR "The nqm.irimager package only currently supports POSIX/UNIX systems.")
+endif()
+
+set_target_properties(irlogger_to_spd PROPERTIES
+  PRIVATE_HEADER
+    "src/nqm/irimager/irlogger_to_spd.hpp"
+  POSITION_INDEPENDENT_CODE ON # -fPIC
+)
+target_link_libraries(irlogger_to_spd
+  PUBLIC
+    propagate_const::propagate_const
+  PRIVATE
+    pybind11::pybind11
+    spdlog::spdlog_header_only
+    irlogger_parser
+)
+
+if(IRImager_mock)
+  target_compile_definitions(irlogger_to_spd PRIVATE IR_IMAGER_MOCK)
+elseif()
+  target_link_libraries(irlogger_to_spd PRIVATE IRImager::IRCore)
+endif()
+
 add_library(logger OBJECT
   "src/nqm/irimager/logger.cpp"
 )
@@ -134,6 +162,7 @@ target_link_libraries(logger
     pybind11::pybind11
   PRIVATE
     spdlog::spdlog_header_only
+    irlogger_to_spd
 )
 
 pybind11_add_module(irimager MODULE
@@ -149,6 +178,8 @@ target_link_libraries(irimager
   PRIVATE
     pybind11::headers
     irimager_class
+    irlogger_parser
+    irlogger_to_spd
     logger
 )
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ We recommend using [PDM](https://pdm.fming.dev/latest/) for local development.
 pdm install
 ```
 
+### Usage
+
+```python
+import logging
+from nqm.irimager import IRImager, Logger
+
+logging.basicConfig()
+logging.getLogger().setLevel(1) # trace
+logger = Logger()
+# Your XML config,
+# see http://documentation.evocortex.com/libirimager2/html/Overview.html#subsec_overview_config_file
+XML_CONFIG = "tests/__fixtures__/382x288@27Hz.xml"
+irimager = IRImager(XML_CONFIG)
+with irimager:
+    while True: # press CTRL+C to stop this program
+        array, timestamp = irimager.get_frame()
+        frame_in_celsius = array / (10 ** irimager.get_temp_range_decimal()) - 100
+        print(f"At {timestamp}: Average temperature is {frame_in_celsius.mean()}")
+        break
+
+del logger # to stop
+```
+
 ## Development
 
 ### Pre-commit checks (linting and type checks)

--- a/src/nqm/irimager/__init__.pyi
+++ b/src/nqm/irimager/__init__.pyi
@@ -78,11 +78,13 @@ class IRImagerMock(IRImager):
     """
 
 class Logger:
-    """Handles converting C++ spdlog to Python :py:class:`logging.Logger`.
+    """Handles converting C++ logs to Python :py:class:`logging.Logger`.
 
     After you instantiate an object of this class, all spdlogs will no longer
     be printed to ``stderr``. Instead, they'll go to callback you've defined,
     or a :py:class:`logging.Logger`.
+
+    Additionally, evo::IRLogger logs will also be captured.
 
     Only a single instance of this object can exist at a time.
     You must destroy existing instances to create a new instance.

--- a/src/nqm/irimager/chrono.hpp
+++ b/src/nqm/irimager/chrono.hpp
@@ -1,0 +1,71 @@
+#ifndef CHRONO_HPP
+#define CHRONO_HPP
+
+#include <chrono>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/chrono.h>  // needed for logging/formatting std::chrono
+
+namespace nqm {
+namespace irimager {
+
+/**
+ * Finds the next whole second.
+ */
+inline std::chrono::time_point<std::chrono::system_clock> next_second(
+    std::chrono::time_point<std::chrono::system_clock> now =
+        std::chrono::system_clock::now()) {
+  auto now_seconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
+
+  return now_seconds + std::chrono::seconds(1);
+}
+
+/**
+ * Block/wait until the next second if we're in the last @p period of a second.
+ */
+template <typename Rep, typename Period>
+inline void wait_if_at_end_of_second(
+    std::chrono::duration<Rep, Period> period) {
+  auto now = std::chrono::system_clock::now();
+
+  if (next_second(now) - now < period) {
+    spdlog::debug("Waiting {} until next second", next_second(now) - now);
+    std::this_thread::sleep_until(next_second(now));
+    spdlog::trace("Waited {}", std::chrono::system_clock::now() - now);
+  }
+}
+
+/**
+ * Gets the datestring format that evo::IRLogger uses.
+ *
+ * E.g., for time `2023-09-18T21:27:53`, returns `18_9_2023_21-27-53`.
+ *
+ * Please be aware, that due to daylight savings or other timezone changes,
+ * multiple times may map to the same datestring 😭.
+ *
+ * All of these numbers don't use 0 prefixes, so we can't use
+ * std::formatter<std::chrono::sys_time>.
+ */
+inline std::string evo_irlogger_datestring(
+    const std::chrono::time_point<std::chrono::system_clock> &time_point) {
+  auto t = std::chrono::system_clock::to_time_t(time_point);
+  auto tm_ptr = std::localtime(&t);
+  if (tm_ptr == nullptr) {
+    // remind me: this code will overflow in the year 2 147 483 648 AD
+    throw std::system_error(errno, std::generic_category());
+  }
+  auto tm = *tm_ptr;
+
+  auto stringstream = std::stringstream();
+
+  // all of these numbers don't have leading `0`s 😭😭😭
+  stringstream << tm.tm_mday << "_" << tm.tm_mon + 1 << "_" << tm.tm_year + 1900
+               << "_" << tm.tm_hour << "-" << tm.tm_min << "-" << tm.tm_sec;
+
+  return stringstream.str();
+}
+
+}  // namespace irimager
+}  // namespace nqm
+
+#endif /* CHRONO_HPP */

--- a/src/nqm/irimager/irlogger_to_spd.hpp
+++ b/src/nqm/irimager/irlogger_to_spd.hpp
@@ -1,0 +1,48 @@
+#ifndef NQM_IRIMAGER_IRLOGGER_TO_SPD
+#define NQM_IRIMAGER_IRLOGGER_TO_SPD
+
+#include <filesystem>
+#include <memory>
+
+#include <propagate_const.h>
+
+#include "./definitions.hpp"
+
+/**
+ * Handles capturing evo::IRLogger logs and passing them to a C++ callback.
+ *
+ * Since the only API that evo::IRLogger makes public is through a file,
+ * we use a FIFO file socket to capture the data.
+ *
+ * @warning Creating multiple instances of IRLoggerToSpd is undefined behaviour.
+ *          I haven't tested it, and the official evo::IRLogger docs say nothing
+ *          about it, so your milage may vary.
+ */
+class IRLoggerToSpd {
+ public:
+  /**
+   * Creates an IRLoggerToSpd using a random named socket.
+   *
+   * - The socket is placed into `$XDG_RUNTIME_DIR/nqm-irimager/` if it exists.
+   * - Otherwise, an `{std::filesystem::temp_directory_path()}/nqm-irimager/`
+   *   is used.
+   */
+  IRLoggerToSpd(const LoggingCallback &logging_callback);
+  /**
+   * Creates an IRLoggerToSpd using a socket on the given path.
+   */
+  IRLoggerToSpd(const LoggingCallback &logging_callback,
+                const std::filesystem::path &socket_path);
+
+  virtual ~IRLoggerToSpd();
+
+  /** pImpl implementation */
+  struct impl;
+
+ private:
+  // pImpl, see https://en.cppreference.com/w/cpp/language/pimpl
+  std::experimental::fundamentals_v2::propagate_const<std::unique_ptr<impl>>
+      pImpl;
+};
+
+#endif /** NQM_IRIMAGER_IRLOGGER_TO_SPD */

--- a/src/nqm/irimager/irlogger_to_spd_posix.cpp
+++ b/src/nqm/irimager/irlogger_to_spd_posix.cpp
@@ -1,0 +1,459 @@
+#include "./irlogger_to_spd.hpp"
+
+#if __has_include(<unistd.h>)
+// this is fine!! Expected behavior
+#else
+#error \
+    "This file requires OS functions that are only available on POSIX systems"
+#endif
+
+extern "C" {
+#include <unistd.h>
+}
+
+#ifndef _POSIX_VERSION
+#error \
+    "This file requires OS functions that are only available on POSIX systems"
+#endif
+
+#include <atomic>
+#include <cerrno>  // POSIX errno
+#include <exception>
+#include <future>
+#include <memory>
+
+extern "C" {
+// needed for the mkfifo() command
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+}
+
+#include <pybind11/pybind11.h>
+#include <spdlog/spdlog.h>
+
+#include "./chrono.hpp"
+#include "./irlogger_parser.hpp"
+
+/** RAII wrapper to handle reading from a POSIX FIFO */
+class PosixFileReadOnly {
+ public:
+  PosixFileReadOnly(const std::filesystem::path &_path) : path{_path} {
+    posix_file_descriptor = open(path.string().c_str(), O_RDONLY | O_NONBLOCK);
+    if (posix_file_descriptor == -1) {
+      auto exception =
+          std::system_error(std::error_code(errno, std::system_category()));
+      spdlog::error("Failed to open file at {} due to {}", path.string(),
+                    exception.what());
+      throw exception;
+    }
+  }
+
+  /**
+   * Tries reading some bytes from the file without blocking.
+   *
+   * @param[out] buffer The buffer to store data in.
+   * @throws std::system_error when there is an non-transient error.
+   * @returns the number of bytes read.
+   *          This will be 0 if there was a transient error
+   *          (e.g. `EINTR` or `EAGAIN`).
+   */
+  template <class C>
+  std::size_t try_read(C &buffer) {
+    ssize_t bytes =
+        read(posix_file_descriptor, std::data(buffer), std::size(buffer));
+    if (bytes <= -1) {
+      switch (errno) {
+        case EINTR:
+          [[fallthrough]];
+        case EAGAIN:
+          return false;
+        default: {
+          auto exception =
+              std::system_error(std::error_code(errno, std::system_category()));
+          spdlog::error("Failed to read file at {} due to {}", path.string(),
+                        exception.what());
+          throw exception;
+        }
+      }
+    }
+    return static_cast<std::size_t>(bytes);
+  }
+
+  virtual ~PosixFileReadOnly() {
+    constexpr int MAX_RETRIES = 128;
+    for (int i = 0; i < MAX_RETRIES; i++) {
+      if (close(posix_file_descriptor) == 0) {
+        return;
+      }
+      if (errno == EINTR) {
+        continue;  // interuptted, retry
+      } else {
+        auto exception =
+            std::system_error(std::error_code(errno, std::system_category()));
+        spdlog::error("Failed to close file at {} due to {}", path.string(),
+                      exception.what());
+        return;
+      }
+    }
+    auto exception =
+        std::system_error(std::error_code(EINTR, std::system_category()));
+    spdlog::error("Failed to close file at {} after {} iterations due to {}",
+                  path.string(), MAX_RETRIES, exception.what());
+  }
+
+  int fd() { return posix_file_descriptor; }
+
+ private:
+  int posix_file_descriptor = -1;
+  std::filesystem::path path;
+};
+
+/**
+ * Handles reading from the IRLogger log file and calling the given callback
+ * function.
+ */
+class IRLoggerReader {
+ public:
+  IRLoggerReader(LoggingCallback _logging_callback,
+                 const std::filesystem::path &socket_path)
+      : ir_logger_parser{_logging_callback} {
+    start_thread(socket_path);
+  }
+
+  virtual ~IRLoggerReader() {
+    try {
+      stop_thread();
+    } catch (std::exception &e) {
+      spdlog::error("IRLoggerReader thread crashed: {}", e.what());
+    }
+  }
+
+ private:
+  void start_thread(const std::filesystem::path &socket_path) {
+    spdlog::debug("Making FIFO at {} for logging", socket_path.string());
+
+    if (mkfifo(socket_path.string().c_str(), 0600) != 0) {
+      if (errno != EEXIST) {
+        auto exception =
+            std::system_error(std::error_code(errno, std::system_category()));
+        spdlog::error("IRLoggerReader failed to create pipe at {} due to {}",
+                      socket_path.string(), exception.what());
+        throw exception;
+      }
+    }
+
+    spdlog::debug("starting thread");
+    logger_thread = std::async(std::launch::async, [this, socket_path]() {
+      spdlog::debug("Started new thread to read from {}", socket_path.string());
+
+      thread_handle = pthread_self();
+
+      // Ignore SIGUSR1 signals on this thread.
+      // POSIX functions will be interrupted and fail with EINTR
+      struct sigaction signal_action = {};
+      signal_action.sa_handler = SIG_IGN;
+      signal_action.sa_flags &=
+          ~SA_RESTART;  // force functions to throw EINTR on signals
+
+      if (sigaction(SIGUSR1, &signal_action, nullptr) != 0) {
+        auto exception =
+            std::system_error(std::error_code(errno, std::system_category()));
+        spdlog::error(
+            "IRLoggerReader failed to create SIGUSR1 signal handler due to "
+            "{}",
+            exception.what());
+        throw exception;
+      }
+
+      auto fifo_pipe = PosixFileReadOnly(socket_path);
+
+      struct pollfd fifo_pollfd = {};
+      fifo_pollfd.fd = fifo_pipe.fd();
+      fifo_pollfd.events |= POLL_IN;
+
+      auto read_buffer = std::array<char, 1024>();
+
+      while (stop == false) {
+        /*
+         * Check every 5 seconds if `stop == true`.
+         *
+         * Normally, poll() should immediately throw an EINTR when a USRSIG1
+         * signal is caught, but for reason, this only works some of the
+         * time. Once we fix this we, could set the timeout to `-1`
+         * (infinity).
+         */
+        constexpr int POLL_TIMEOUT = 5000;
+        int result = poll(&fifo_pollfd, 1, POLL_TIMEOUT);
+
+        if (result == 0) {  // timeout, loop again
+          continue;
+        } else if (result == -1) {  // handle error
+          if (errno == EINTR) {
+            // signal interrupt is fine, we just need to check if `stop ==
+            // true`.
+            continue;
+          }
+          auto exception =
+              std::system_error(std::error_code(errno, std::system_category()));
+          spdlog::error("polling FIFO file at {} failed due to {}",
+                        socket_path.string(), exception.what());
+          throw exception;
+        }
+
+        if (fifo_pollfd.revents & POLLERR) {
+          // POLL error? TODO: what does this mean?
+          spdlog::warn("polling FIFO file at {} got POLLERR",
+                       socket_path.string());
+        }
+        if (fifo_pollfd.revents & (POLLIN | POLLPRI)) {
+          // data is available for reading on the pipe
+          std::size_t bytes = fifo_pipe.try_read(read_buffer);
+          if (bytes > 0) {
+            handle_bytes(std::data(read_buffer), bytes);
+          }
+        }
+      }
+    });
+  }
+
+  void stop_thread() {
+    auto no_gil = pybind11::gil_scoped_release();
+    stop = true;
+
+    auto thread_handle_value = thread_handle.load();
+    if (thread_handle_value) {
+      // this should interrupt any slow read() or poll() commands, and make
+      // the child thread exit faster (although it only works most of the time)
+      pthread_kill(thread_handle_value, SIGUSR1);
+    }
+    logger_thread.get();
+  }
+
+  std::shared_future<void> logger_thread;
+
+  /** If `true`, stop the logger thread */
+  std::atomic<bool> stop = false;
+
+  /**
+   * Logging thread handle, only used to send signals to the child thread to
+   * interrupt it (stops it quicker).
+   */
+  std::atomic<pthread_t> thread_handle = 0;
+
+  /**
+   * Handles parsing the logs.
+   */
+  IRLoggerParser ir_logger_parser;
+
+  /*
+   * Handle some bytes from the log file
+   */
+  void handle_bytes(const char *bytes, std::size_t size) {
+    ir_logger_parser.push_data(bytes, size);
+  }
+};
+
+/**
+ * Gets the real filename that the evo::IRLogger writes to.
+ *
+ * If you input `my-file.log`, you'll get something like
+ * `my-file.log_18_9_2023_21-27-53.log` out.
+ *
+ * @param irlogger_log_path_prefix - The prefix of the log file.
+ * @param delay_if_at_end_of_second - A number of milliseconds between 1000 and
+ * 0. If we're in the last bit of a second, block this function from returning
+ * until the next second to avoid race-conditions.
+ */
+static std::filesystem::path irlogger_log_path(
+    const std::filesystem::path &irlogger_log_path_prefix,
+    std::chrono::milliseconds delay_if_at_end_of_second =
+        std::chrono::milliseconds(100)) {
+  nqm::irimager::wait_if_at_end_of_second(delay_if_at_end_of_second);
+
+  return irlogger_log_path_prefix.string() + "_" +
+         nqm::irimager::evo_irlogger_datestring(
+             std::chrono::system_clock::now()) +
+         ".log";
+}
+
+#ifdef IR_IMAGER_MOCK
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <thread>
+
+/**
+ * Mock class that logs data to given socket.
+ */
+class IRLoggerImpl {
+ public:
+  IRLoggerImpl(const std::filesystem::path &socket_path_prefix) {
+    auto real_socket_path = irlogger_log_path(socket_path_prefix);
+    irlogger_mock_thread = std::async(
+        std::launch::async,
+        [real_socket_path,  // by-copy capture, since this will run in another
+                            // thread
+         this] {
+          auto out = std::ofstream(real_socket_path);
+          out << "WARNING [irlogger_to_spd_posix.cpp:" << __LINE__
+              << "] @ 0.01s :Mocking IRLogger output." << std::endl;
+          for (int i = 0; i < 3600 && !this->stop; i++) {
+            out << "DEBUG [irlogger_to_spd_posix.cpp:" << __LINE__ << "] @ "
+                << i << "s :This is some dummy mocked IRLogger output."
+                << std::endl;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+          }
+        });
+  }
+
+  ~IRLoggerImpl() { stop_thread(); }
+
+ private:
+  std::shared_future<void> irlogger_mock_thread;
+  std::atomic<bool> stop = false;
+
+  void stop_thread() {
+    auto no_gil = pybind11::gil_scoped_release();
+    stop = true;
+    irlogger_mock_thread.get();
+  }
+};
+#else /* IR_IMAGER_MOCK */
+
+#include <libirimager/IRLogger.h>
+
+/**
+ * @brief Run the given function with a timeout.
+ *
+ * @param function The function to run.
+ * @param timeout The timeout.
+ * @throws std::system_error if killing the function failed.
+ * @throws std::exception from the function if the function throws an exception.
+ * @retval std::future_status::ready if the function finished on time.
+ * @retval std::future_status::timeout if the function timed-out.
+ */
+std::future_status run_with_timeout(std::function<void()> function,
+                                    std::chrono::milliseconds timeout) {
+  auto task = std::packaged_task<void()>(function);
+  auto future = task.get_future();
+
+  auto thread = std::thread(std::move(task));
+
+  switch (future.wait_for(timeout)) {
+    case std::future_status::ready:
+      thread.join();
+      future.get();  // throws an exception if the thread threw an exception.
+      return std::future_status::ready;  // success!
+    case std::future_status::deferred:
+      thread.detach();
+      // TODO: check if this is impossible
+      throw new std::runtime_error("deferred");
+    case std::future_status::timeout:
+      // thread.native_handle() may only exist on POSIX, not on windows!!
+      if (pthread_cancel(thread.native_handle()) != 0) {
+        thread.detach();  // will leak, but this should almost never happen
+        throw std::system_error(std::error_code(errno, std::system_category()),
+                                "Failed to stop thread after timeout");
+      }
+      thread.join();
+      return std::future_status::timeout;
+  }
+
+  throw new std::runtime_error("Unknown std::future_status value");
+}
+
+/**
+ * Logs data to given socket.
+ */
+class IRLoggerImpl {
+ private:
+  static constexpr auto TIMEOUT = std::chrono::seconds(5);
+
+ public:
+  IRLoggerImpl(const std::filesystem::path &socket_path_prefix) {
+    spdlog::debug("Starting evo::IRLogger to file {}.some_time",
+                  socket_path_prefix.string());
+    auto no_gil = pybind11::gil_scoped_release();  // the setVerbosity()
+                                                   // function freezes sometimes
+
+    // evo::IRLogger::setVerbosity() has a bug that occasionally causes it to
+    // freeze due to a deadlock, see
+    // https://github.com/nqminds/nqm-irimager/issues/51#issuecomment-1750614144
+    // Having a timeout is a crappy workaround, but it's better than nothing.
+    if (run_with_timeout(std::bind(evo::IRLogger::setVerbosity,
+                                   evo::IRLoggerVerbosityLevel::IRLOG_OFF,
+                                   evo::IRLoggerVerbosityLevel::IRLOG_DEBUG,
+                                   socket_path_prefix.string().c_str()),
+                         TIMEOUT) == std::future_status::timeout) {
+      throw new std::runtime_error(
+          "Timeout when calling evo::IRLogger::setVerbosity");
+    }
+    spdlog::trace("Started evo::IRLogger");
+  }
+
+  ~IRLoggerImpl() {
+    if (run_with_timeout(
+            std::bind(evo::IRLogger::setVerbosity,
+                      evo::IRLoggerVerbosityLevel::IRLOG_OFF,
+                      evo::IRLoggerVerbosityLevel::IRLOG_OFF, nullptr),
+            TIMEOUT) == std::future_status::timeout) {
+      spdlog::error("Timeout when trying to stop evo::IRLogger");
+    }
+  }
+};
+#endif /* IR_IMAGER_MOCK */
+
+struct IRLoggerToSpd::impl {
+ public:
+  impl(const LoggingCallback &logging_callback,
+       const std::filesystem::path &socket_path)
+      : log_file_reader(logging_callback, irlogger_log_path(socket_path)),
+        irlogger_impl(socket_path) {}
+
+ private:
+  IRLoggerReader log_file_reader;
+  IRLoggerImpl irlogger_impl;
+};
+
+/**
+ * @see IRLoggerToSpd::IRLoggerToSpd() documentation.
+ */
+static std::filesystem::path default_socket_path() {
+  const char *xdg_runtime_dir_ptr = std::getenv("XDG_RUNTIME_DIR");
+  if (xdg_runtime_dir_ptr) {
+    auto xdg_runtime_dir =
+        std::filesystem::path(xdg_runtime_dir_ptr) / "nqm-irimager";
+    try {
+      std::filesystem::create_directory(xdg_runtime_dir);
+      return xdg_runtime_dir / "irlogger.fifo";
+    } catch (const std::filesystem::filesystem_error &e) {
+      // on no_such_file_or_directory error, just use temp_directory_path()
+      if (e.code() != std::errc::no_such_file_or_directory) {
+        throw e;
+      }
+    }
+  }
+
+  auto temp_dir = std::filesystem::temp_directory_path() / "nqm-irimager";
+  std::filesystem::create_directory(temp_dir);
+  return temp_dir / "irlogger.fifo";
+}
+
+IRLoggerToSpd::IRLoggerToSpd(const LoggingCallback &logging_callback)
+    : IRLoggerToSpd(logging_callback, default_socket_path()) {}
+
+IRLoggerToSpd::IRLoggerToSpd(const LoggingCallback &logging_callback,
+                             const std::filesystem::path &socket_path) {
+  auto gil = pybind11::gil_scoped_acquire();
+  pImpl = std::make_unique<IRLoggerToSpd::impl>(logging_callback, socket_path);
+}
+
+IRLoggerToSpd::~IRLoggerToSpd() {
+  auto gil = pybind11::gil_scoped_acquire();
+  pImpl = nullptr;
+}

--- a/src/nqm/irimager/logger.cpp
+++ b/src/nqm/irimager/logger.cpp
@@ -5,6 +5,8 @@
 #include <spdlog/sinks/callback_sink.h>
 #include <spdlog/spdlog.h>
 
+#include "./irlogger_to_spd.hpp"
+
 /** Map spdlog's spd::level::level_enum enum to our LogLevel enum */
 static LogLevel spd_level_to_irimager_level(
     spdlog::level::level_enum input) noexcept {
@@ -42,13 +44,27 @@ struct Logger::impl {
    *
    * @param logging_callback The function to call with log data.
    */
-  impl(LoggingCallback logging_callback) { redirect_spd(logging_callback); }
+  impl(LoggingCallback logging_callback) {
+    redirect_spd(logging_callback);
 
-  virtual ~impl() { reset_spd_redirect(); }
+    spdlog::debug("set up Python logging callback");
+
+    // construct after calling redirect_spd, so we can see logs during
+    // construction
+    ir_logger_to_spd = std::make_unique<IRLoggerToSpd>(logging_callback);
+  }
+
+  virtual ~impl() {
+    ir_logger_to_spd = nullptr;
+    reset_spd_redirect();
+  }
 
  private:
   /** If we've called redirect_spd(), this var stores the original logger */
   std::shared_ptr<spdlog::logger> old_logger;
+
+  /** Handles piping IRImageSDK logs to spdlog */
+  std::unique_ptr<IRLoggerToSpd> ir_logger_to_spd;
 
   /** Redirects calls to `spdlog::log()` in C++ to the given callback */
   void redirect_spd(LoggingCallback logging_callback) {

--- a/src/nqm/irimager/logger.hpp
+++ b/src/nqm/irimager/logger.hpp
@@ -9,11 +9,13 @@
 #include "./definitions.hpp"
 
 /**
- * Handles converting C++ spdlog to Python :py:class:`logging.Logger`.
+ * Handles converting C++ logs to Python :py:class:`logging.Logger`.
  *
  * After you instantiate an object of this class, all spdlogs will no longer
  * be printed to ``stderr``. Instead, they'll go to callback you've defined,
  * or a :py:class:`logging.Logger`.
+ *
+ * Additionally, evo::IRLogger logs will also be captured.
  *
  * Only a single instance of this object can exist at a time.
  * You must destroy existing instances to create a new instance.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,15 @@ add_custom_target(copy-fixtures ALL
   "${CMAKE_CURRENT_BINARY_DIR}/__fixtures__"
 )
 
+add_executable(test_chrono
+  test_chrono.cpp
+)
+target_link_libraries(test_chrono
+  PRIVATE
+    GTest::gtest_main
+    spdlog::spdlog_header_only
+)
+
 add_executable(test_irimager_class
   test_irimager_class.cpp
 )

--- a/tests/test_chrono.cpp
+++ b/tests/test_chrono.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include <iomanip>
+#include <sstream>
+#include <utility>
+
+#include "../src/nqm/irimager/chrono.hpp"
+
+std::chrono::time_point<std::chrono::system_clock> parse_iso8601(
+    std::string iso8601_datetime) {
+  auto stringstream = std::istringstream();
+  stringstream.str(iso8601_datetime);
+  stringstream.exceptions(std::ios_base::failbit);
+
+  std::tm tm = {};
+  stringstream >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
+
+  // daylight savings usually only occurs between 23:00 and 03:59, so if we
+  // ignore these hours, we shouldn't have to worry about ambigious dates
+  // (we're stuck on C++17, so we can't use stdlibc++ timezone funcs)
+  if (23 <= tm.tm_hour || tm.tm_hour < 4) {
+    throw new std::invalid_argument("The date " + iso8601_datetime +
+                                    " is potentially ambigious due to daylight "
+                                    "savings. Please pick a different hour.");
+  }
+  tm.tm_isdst = -1;  // pick DST/not-DST automatically
+
+  return std::chrono::system_clock::from_time_t(std::mktime(&tm));
+}
+
+class TestEvoIRLoggerDatestring
+    : public testing::TestWithParam<std::pair<std::string, std::string>> {};
+
+TEST_P(TestEvoIRLoggerDatestring, ShouldMatchExpectedValue) {
+  const auto& [iso_date, expected_output] = GetParam();
+
+  EXPECT_EQ(nqm::irimager::evo_irlogger_datestring(parse_iso8601(iso_date)),
+            expected_output);
+}
+
+INSTANTIATE_TEST_SUITE_P(ShouldMatchExpectedValue, TestEvoIRLoggerDatestring,
+                         ::testing::Values((std::pair<std::string, std::string>{
+                             "2023-09-18T21:27:53", "18_9_2023_21-27-53"})));


### PR DESCRIPTION
**This PR depends on**:
  - #69

Please switch the target branch for this PR to `main` after the above PR has been merged.

---

Add the `IRLoggerToSpd` class, that converts from [IRImagerDirect SDK's `evo::IRLogger` logs][1] to [spdlog](https://github.com/gabime/spdlog).

This allows us to see all of the logging messages that the IRImagerDirect SDK prints. This is especially important for errors, since the IRImagerDirect SDK does not throw exceptions, it just returns `false` (or `true`, depending on the function) if there is an error, and you need to view the logs to see why a function failed.

I've also modified the `nqm.irimager.Logger` Python class to automatically use this code, so we can just do the following to see all the logs:

```python
import logging
logging.basicConfig()
logging.getLogger().setLevel(logging.INFO) # view all INFO or higher messages

from nqm.irimager import IRImager, Logger

logger = Logger()
irimager = IRImager("tests/__fixtures__/382x288@27Hz.xml")
```

### Implementation details

Since `evo::IRLogger` only supports using a file for output, we're using POSIX-specific APIs to automatically listen on the file and pipe the output to a `IRLoggerParser` C++ class (added in PR #69).

I'm using a FIFO POSIX pipe file, so we don't need to worry about disk space running out.

In the future, we should switch to using something like [uvw][] to automatically handle OS differences. I've just picked raw C POSIX functions to implement things as quickly as possible.

#### `evo::IRLogger::setVerbosity()` filename

The `filename` parameter that we pass to `evo::IRLogger::setVerbosity()` isn't the actual filename that `evo::IRLogger` writes to. Instead, it appends the current datetime in a bonkers format to the filename. E.g. if you pass `"my-log-file"` and the time is currently 2023-09-18T21:27:53 in your local timezone, it will write to `"my-log-file_18_9_2023_21-27-53.log"` :facepalm:. I've added a function called `nqm::irimager::evo_irlogger_datestring` to reverse-engineer this time-format.

[1]: http://documentation.evocortex.com/libirimager2/html/classevo_1_1IRLogger.html
[uvw]: https://github.com/skypjack/uvw