### PR TITLE
Implement `nqm.irimager.IRImager` code with a real thermal camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Python module for interfacing with [EvoCortex IRImagerDirect SDK][1].
 (known as `libirimager`). Please follow the instructions on their webpage to
 install the package.
 
+You will also need to
+- Download calibration data using `sudo ir_download_calibration`, see
+  <http://documentation.evocortex.com/libirimager2/html/Installation.html#subsec_download>
+- Create an XML configuration file using `ir_generate_configuration`, see
+  <http://documentation.evocortex.com/libirimager2/html/Installation.html#subsec_config>
+
 It's possible to install a mocked version of `nqm.irimager` for testing
 by defining `SKBUILD_CMAKE_DEFINE='IRImager_mock=ON'` whiling building
 `nqm.irimager`.
@@ -33,9 +39,13 @@ We recommend using [PDM](https://pdm.fming.dev/latest/) for local development.
 pdm install
 ```
 
-### Usage
+## Usage example
+
+See documentation for the full API reference, but using this library is as
+easy as:
 
 ```python
+import datetime
 import logging
 from nqm.irimager import IRImager, Logger
 
@@ -47,11 +57,15 @@ logger = Logger()
 XML_CONFIG = "tests/__fixtures__/382x288@27Hz.xml"
 irimager = IRImager(XML_CONFIG)
 with irimager:
+    print(f"Started at {datetime.datetime.now()}")
     while True: # press CTRL+C to stop this program
-        array, timestamp = irimager.get_frame()
+        try:
+          array, timestamp = irimager.get_frame()
+        except error:
+          print(f"Stopped at {datetime.datetime.now()}")
+          raise error
         frame_in_celsius = array / (10 ** irimager.get_temp_range_decimal()) - 100
         print(f"At {timestamp}: Average temperature is {frame_in_celsius.mean()}")
-        break
 
 del logger # to stop
 ```

--- a/src/nqm/irimager/__init__.pyi
+++ b/src/nqm/irimager/__init__.pyi
@@ -47,12 +47,20 @@ class IRImager:
     def get_frame(self) -> typing.Tuple[npt.NDArray[np.uint16], datetime.datetime]:
         """Return a frame
 
+        If the shutter is down (normally done automatically by the thermal
+        camera for calibration), this function will wait until the shutter is
+        back up, before returning (usually around ~1s).
+
+        Throws:
+            RuntimeError if a frame cannot be loaded, e.g. if the camera isn't
+            streaming.
+
         Returns:
             A tuple containing:
-                - A 2-D matrix containing the image. This must be adjusted
-                  by :py:meth:`~IRImager.get_temp_range_decimal` to get the
-                  actual temperature in degrees Celcius.
-                - The time the image was taken.
+              1. A 2-D matrix containing the image. This must be adjusted by
+                 :py:meth:`~IRImager.get_temp_range_decimal` to get the actual
+                 temperature in degrees Celcius, offset from -100 ℃.
+              2. The time the image was taken.
         """
     def get_temp_range_decimal(self) -> int:
         """The number of decimal places in the thermal data

--- a/src/nqm/irimager/chrono.hpp
+++ b/src/nqm/irimager/chrono.hpp
@@ -10,6 +10,29 @@ namespace nqm {
 namespace irimager {
 
 /**
+ * Converts from `steady_clock` to `system_clock`.
+ *
+ * Converts a time_point from std::chrono::steady_clock (time since last boot)
+ * to std::chrono::system_clock (aka time since UNIX epoch).
+ *
+ * C++20 has a function called std::chrono::clock_cast that will do this
+ * for us, but we're stuck on C++17, so instead we have to do this imprecise
+ * monstrosity to do the conversion.
+ *
+ * @remarks
+ * This function is imprecise!!! Calling it multiple times with the same data
+ * will result in different results.
+ */
+inline std::chrono::time_point<std::chrono::system_clock> clock_cast(
+    const std::chrono::time_point<std::chrono::steady_clock>
+        &steady_time_point) {
+  auto sys_now = std::chrono::system_clock::now();
+  auto sdy_now = std::chrono::steady_clock::now();
+  return std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+      steady_time_point - sdy_now + sys_now);
+}
+
+/**
  * Finds the next whole second.
  */
 inline std::chrono::time_point<std::chrono::system_clock> next_second(

--- a/src/nqm/irimager/irimager_class.cpp
+++ b/src/nqm/irimager/irimager_class.cpp
@@ -1,6 +1,17 @@
 #include "./irimager_class.hpp"
 
-#include "spdlog/spdlog.h"
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <variant>
+
+#include <spdlog/spdlog.h>
+
+#include "./chrono.hpp"
 
 struct IRImager::impl {
  public:
@@ -86,8 +97,60 @@ struct IRImagerMockImpl final : public IRImager::impl {
 #define IRImagerDefaultImplementation IRImagerMockImpl
 #else  // not mocked
 
-#include "libirimager/IRDevice.h"
-#include "libirimager/IRImager.h"
+#include <libirimager/IRDevice.h>
+#include <libirimager/IRDeviceParams.h>
+#include <libirimager/IRImager.h>
+#include <libirimager/IRLogger.h>
+
+/**
+ * Exception class to convert evo::IRDeviceError to a human readable error.
+ */
+class IRDeviceException : public std::runtime_error {
+ public:
+  IRDeviceException(evo::IRDeviceError ir_device_error)
+      : std::runtime_error(enum_to_string_message(ir_device_error)) {}
+
+  static std::string enum_to_string_message(
+      evo::IRDeviceError ir_device_error) {
+    switch (ir_device_error) {
+      case evo::IRIMAGER_SUCCESS:
+        throw std::invalid_argument("IRIMAGER_SUCCESS is not an error");
+      case evo::IRIMAGER_NODATA:
+        return "IRIMAGER_NODATA: Error occurred in getting frame. You may need "
+               "to reconnect the camera.";
+      case evo::IRIMAGER_DISCONNECTED:
+        return "IRIMAGER_DISCONNECTED: Error occurred in getting frame. You "
+               "may need to reconnect the camera.";
+      case evo::IRIMAGER_NOSYNC:
+        return "IRIMAGER_NOSYNC: Error occurred in getting frame. You may need "
+               "to reconnect the camera.";
+      case evo::IRIMAGER_STREAMOFF:
+        return "IRIMAGER_STREAMOFF: Not streaming";
+      case evo::IRIMAGER_EAGAIN:
+        return "IRIMAGER_EAGAIN: Error occurred in getting frame. You may need "
+               "to reconnect the camera.";
+      case evo::IRIMAGER_EIO:
+        return "IRIMAGER_EIO: Error occurred in getting frame. You may need to "
+               "reconnect the camera.";
+      case evo::IRIMAGER_EUNKNOWN:
+        return "IRIMAGER_EUNKNOWN: Error occurred in getting frame. You may "
+               "need to reconnect the camera.";
+    }
+
+    return "IRImager::getFrame() returned an unknown error code";
+  }
+};
+
+template <class, class = void>
+struct has_get_temp_range_decimal : std::false_type {};
+
+/**
+ * True if the given class has a `get_temp_range_decimal()` method.
+ */
+template <class T>
+struct has_get_temp_range_decimal<
+    T, std::void_t<decltype(std::declval<T>().get_temp_range_decimal())> >
+    : std::true_type {};
 
 /**
  * Real implentation, requires both a working irimager library, camera, and
@@ -96,10 +159,133 @@ struct IRImagerMockImpl final : public IRImager::impl {
 struct IRImagerRealImpl final : public IRImager::impl {
  public:
   IRImagerRealImpl() = default;
-  IRImagerRealImpl(const IRImager::impl &other) : IRImager::impl(other) {}
-  IRImagerRealImpl(const std::filesystem::path &xml_path)
-      : IRImager::impl(xml_path) {}
+
+  IRImagerRealImpl(const IRImager::impl &other) : IRImager::impl(other) {
+    auto other_real = dynamic_cast<const IRImagerRealImpl *>(&other);
+    if (other_real != nullptr) {
+      ir_device = other_real->ir_device;
+    }
+  }
+
+  IRImagerRealImpl(const std::filesystem::path &xml_path) {
+    evo::IRDeviceParams params;
+    if (evo::IRDeviceParamsReader::readXMLC(xml_path.c_str(), params)) {
+      // do a basic check that the given file is readable, and is an XML file
+      auto xml_stream = std::ifstream(xml_path, std::fstream::in);
+      auto xml_header = std::string(5, '\0');
+      xml_stream.read(xml_header.data(),
+                      static_cast<std::streamsize>(xml_header.size()));
+      if (xml_header != std::string("<?xml")) {
+        throw std::runtime_error(
+            "Invalid XML file: The given XML file does not start with '<?xml'");
+      }
+
+      // I'm not sure why, but readXMLC seems to always fail for me.
+      // The IRImagerLogs don't show any warnings and ignoring the error seems
+      // to work fine, so 🤷
+      spdlog::warn("Ignoring error when reading XML file at {}.",
+                   xml_path.string());
+    }
+
+    ir_device.reset(evo::IRDevice::IRCreateDevice(params));
+
+    if (ir_device == nullptr) {
+      throw std::runtime_error("Failed to create IRDevice");
+    }
+
+    ir_imager.init(&params, ir_device->getFrequency(), ir_device->getWidth(),
+                   ir_device->getHeight(), ir_device->controlledViaHID());
+    ir_imager.setThermalFrameCallback(&onThermalFrame);
+  }
+
   virtual ~IRImagerRealImpl() = default;
+
+  void start_streaming() override {
+    // despite what the docs say, startStreaming() returns 0 on success, non-0
+    // on failure
+    if (ir_device->startStreaming() != 0) {
+      throw std::runtime_error(
+          "Error occurred in starting stream. You may need to reconnect the "
+          "camera.");
+    }
+  }
+
+  virtual void stop_streaming() override {
+    // despite what the docs say, stopStreaming() returns 0 on success, non-0 on
+    // failure
+    if (ir_device->stopStreaming() != 0) {
+      throw std::runtime_error("Error occurred in stopping stream.");
+    }
+  }
+
+  std::tuple<IRImager::ThermalFrame, std::chrono::system_clock::time_point>
+  get_frame() override {
+    auto raw_frame_bytes =
+        std::vector<unsigned char>(ir_device->getRawBufferSize());
+    /** time of frame, in monotonic seconds since std::chrono::steady_clock */
+    double timestamp;
+    evo::IRDeviceError device_error =
+        ir_device->getFrame(raw_frame_bytes.data(), &timestamp);
+    if (device_error != evo::IRIMAGER_SUCCESS) {
+      throw IRDeviceException(device_error);
+    }
+
+    ir_imager.process(raw_frame_bytes.data(), static_cast<void *>(this));
+
+    std::variant<IRImager::ThermalFrame, BadFrame, nullptr_t>
+        thermal_data_result = nullptr;
+    {
+      // wait until ir_imager.process() calls the
+      // IRImager::impl::onThermalFrame callback and fills @p thermal_data
+      auto lk = std::unique_lock(mutex);
+
+      if (thermal_data_available.wait_for(lk, std::chrono::seconds(30), [&] {
+            return !std::holds_alternative<nullptr_t>(thermal_data);
+          }) == false) {
+        throw std::runtime_error(
+            "Timeout when waiting for a new thermal frame");
+      }
+
+      thermal_data_result.swap(thermal_data);
+    }
+
+    if (std::holds_alternative<BadFrame>(thermal_data_result)) {
+      switch (std::get<BadFrame>(thermal_data_result)) {
+        case BadFrame::SHUTTER_CLOSED:
+          spdlog::debug("Shutter was down, trying to take a frame again");
+#ifdef __clang__
+          // GCC will tail-call optimize too on x86_64 and ARM64, but even if it
+          // doesn't we're extremely unlikely to have a stack overflow, even if
+          // imaging at 1000Hz
+          [[clang::musttail]] return get_frame();
+#else
+          return get_frame();
+#endif
+      }
+
+      throw std::runtime_error("Failed to get a thermal frame");
+    }
+
+    auto seconds_since_epoch =
+        std::chrono::duration<double, std::ratio<1> >(timestamp);
+    auto nanoseconds_since_epoch =
+        std::chrono::floor<std::chrono::nanoseconds>(seconds_since_epoch);
+
+    // need to convert our double duration to an integer duration
+    auto steady_time_point = std::chrono::time_point<std::chrono::steady_clock>(
+        nanoseconds_since_epoch);
+
+    return std::make_tuple(
+        std::get<IRImager::ThermalFrame>(std::move(thermal_data_result)),
+        nqm::irimager::clock_cast(steady_time_point));
+  }
+
+  short get_temp_range_decimal() override {
+    static_assert(has_get_temp_range_decimal<evo::IRImager>::value == false,
+                  "evo::IRImager has a get_temp_range_decimal function, which "
+                  "should be used instead of this override.");
+    return 1;
+  }
 
   std::string_view get_library_version() override {
     return evo::IRImager::getVersion();
@@ -107,6 +293,76 @@ struct IRImagerRealImpl final : public IRImager::impl {
 
  private:
   std::shared_ptr<evo::IRDevice> ir_device;
+  evo::IRImager ir_imager;
+
+  /**
+   * Enum that explains why a frame might be bad.
+   */
+  enum class BadFrame {
+    /** The shutter was closed, so this frame is only for calibration */
+    SHUTTER_CLOSED,
+  };
+
+  /**
+   * Locks the ::thermal_data_available and ::thermal_data attributes.
+   */
+  std::mutex mutex;
+  /**
+   * Notifies that the ::thermal_data param holds data.
+   */
+  std::condition_variable thermal_data_available;
+  /**
+   * Either a:
+   *   - IRImager::ThermalFrame, containing the thermal frame,
+   *   - ::BadFrame, containing an enum on why the frame is bad,
+   *   - or `nullptr`, which means there is no frame data.
+   */
+  std::variant<IRImager::ThermalFrame, BadFrame, nullptr_t> thermal_data =
+      nullptr;
+
+  /**
+   * Thermal frame callback function.
+   *
+   * Stores the thermal frame in the ::thermal_data attribute, then sends a
+   * notification on ::thermal_data_available to let any listeners know that
+   * a frame has arrived.
+   *
+   * @param[in] thermal Thermal data 2D-array.
+   * @param w           Width of thermal data array.
+   * @param h           Height of thermal data array.
+   * @param meta        Metadata about the frame.
+   * @param[in] arg     Pointer passed to evo::IRImager::process().
+   *                    In our code, this should always be a IRImager::impl
+   *                    object.
+   * @see evo::IRImager::setThermalFrameCallback(fptrIRThermalFrame callback)
+   */
+  static void onThermalFrame(unsigned short *thermal, unsigned int w,
+                             unsigned int h,
+                             [[maybe_unused]] evo::IRFrameMetadata meta,
+                             void *arg) {
+    auto data = static_cast<IRImagerRealImpl *>(arg);
+    {
+      auto lock = std::scoped_lock(data->mutex);
+
+      if (!std::holds_alternative<nullptr_t>(data->thermal_data)) {
+        spdlog::warn(
+            "thermal_data is not empty, this might occur due to calling "
+            "`get_frame()` before the previous `get_frame()` is finished");
+      }
+
+      if (data->ir_imager.isFlagOpen()) {
+        // TODO: evo::IRImager doesn't mention if data is RowMajor/ColumnMajor
+        //       so we're assuming it's RowMajor.
+        auto array = Eigen::Map<IRImager::ThermalFrame>(thermal, w, h);
+
+        data->thermal_data = std::move(array);
+      } else {
+        // shutter is down, frame data is bad
+        data->thermal_data = BadFrame::SHUTTER_CLOSED;
+      }
+    }
+    data->thermal_data_available.notify_one();
+  }
 };
 
 #define IRImagerDefaultImplementation IRImagerRealImpl

--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -78,15 +78,20 @@ class IRImager {
   void stop_streaming();
 
   /**
-   * Return a frame
+   * Return a frame.
+   *
+   * If the shutter is down
+   * (normally done automatically by the thermal camera for calibration),
+   * this function will wait until the shutter is back up, before returning
+   * (usually around ~1s).
    *
    * @throws RuntimeError if a frame cannot be loaded,
-   *   e.g. if the camera isn't streaming.
+   *                      e.g. if the camera isn't streaming.
    *
    * @returns A tuple containing:
    *         1. A 2-D matrix containing the image. This must be adjusted
    *           by :py:meth:`~IRImager.get_temp_range_decimal` to get the
-   *           actual temperature in degrees Celcius.
+   *           actual temperature in degrees Celcius, offset from -100 ℃.
    *         2. The time the image was taken.
    */
   std::tuple<ThermalFrame, std::chrono::system_clock::time_point> get_frame();


### PR DESCRIPTION
**This PR depends on**:
  - #70

Please switch the target branch for this PR to `main` after the above PR has been merged.

---

Replace the mocked functionality in `src/nqm/irimager/irimager_class.cpp` with real calls to the [IRImagerDirect SDK](http://documentation.evocortex.com/libirimager2/html/classevo_1_1IRLogger.html).

Please be aware that calling this function now requires that you have a thermal camera plugged in. If you don't have a camera attached, you can use `from nqm.irimager import IRImagerMock as IRImager` to return some mocked data.

### Implementation details

As far as I can tell, the only way to get the thermal data out of the evo::IRImager is to use [`setThermalFrameCallback()`](http://documentation.evocortex.com/libirimager2/html/classevo_1_1IRImager.html#a1559478fc4b85d001e63784d5eae47b3), and it will then pick when to return the thermal data. Since callbacks aren't really a thing in non-GUI Python code, so I've used a mutex to re-convert it back into non-callback code.

### Potential issues

The `evo::IRImager` documentation is unclear whether the data passed to `setThermalFrameCallback()` is row-major or column-major (see https://github.com/nqminds/nqm-irimager/pull/65 for background) so I'm just assuming it's row-major.

Unfortunately, there isn't an easy way to test this while in the NquiringMinds office. The camera's minimum temperature is 450°C so pointing this at anything in the office pretty much only ever shows 450 °C.

### Notes to reviewers

@AshleySetter, if you want to test this code, you're welcome to SSH into the `nqm-xenacious-xavier` box and try it out there, but from my testing, after weeks of work, everything seems to finally work :rocket: :rocket: :partying_face: !!!