### PR TITLE
refactor: append `_` to class data member names

### DIFF
--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -120,7 +120,7 @@ class IRImager {
  protected:
   // pImpl, see https://en.cppreference.com/w/cpp/language/pimpl
   std::experimental::fundamentals_v2::propagate_const<std::unique_ptr<impl>>
-      pImpl;
+      pImpl_;
 
   /**
    * Uninitialized constructor, should only be used in inheritance.

--- a/src/nqm/irimager/irlogger_parser.hpp
+++ b/src/nqm/irimager/irlogger_parser.hpp
@@ -13,8 +13,8 @@
  */
 class IRLoggerParser {
  public:
-  IRLoggerParser(LoggingCallback _logging_callback)
-      : logging_callback{_logging_callback} {}
+  IRLoggerParser(LoggingCallback logging_callback)
+      : logging_callback_{logging_callback} {}
 
   /**
    * Push some data into the IRLoggerParser, automatically calling the
@@ -33,9 +33,9 @@ class IRLoggerParser {
   static constexpr std::size_t STRING_BUFFER_SIZE = 1 << 20;  // 1 MiB
 
  private:
-  LoggingCallback logging_callback;
+  LoggingCallback logging_callback_;
 
-  StringRingBuffer<STRING_BUFFER_SIZE> buffer;
+  StringRingBuffer<STRING_BUFFER_SIZE> buffer_;
 
   /**
    * @brief Tries to parse a log line from the internal buffer.

--- a/src/nqm/irimager/irlogger_to_spd.hpp
+++ b/src/nqm/irimager/irlogger_to_spd.hpp
@@ -42,7 +42,7 @@ class IRLoggerToSpd {
  private:
   // pImpl, see https://en.cppreference.com/w/cpp/language/pimpl
   std::experimental::fundamentals_v2::propagate_const<std::unique_ptr<impl>>
-      pImpl;
+      pImpl_;
 };
 
 #endif /** NQM_IRIMAGER_IRLOGGER_TO_SPD */

--- a/src/nqm/irimager/logger.hpp
+++ b/src/nqm/irimager/logger.hpp
@@ -45,7 +45,7 @@ class Logger {
 
  private:
   // pImpl, see https://en.cppreference.com/w/cpp/language/pimpl
-  std::shared_ptr<impl> pImpl;
+  std::shared_ptr<impl> pImpl_;
 };
 
 #endif /* NQM_IRIMAGER_LOGGER */

--- a/src/nqm/irimager/string_ring_buffer.hpp
+++ b/src/nqm/irimager/string_ring_buffer.hpp
@@ -29,7 +29,7 @@ class StringRingBuffer {
   /**
    * Returns the number of characters in the buffer.
    */
-  size_t size() { return _size; }
+  size_t size() { return size_; }
 
   /**
    * @brief Insert the string into the buffer.
@@ -38,28 +38,28 @@ class StringRingBuffer {
    *                           for the given string.
    */
   void insert(std::string_view string) {
-    if (_size == data.size()) {
+    if (size_ == data_.size()) {
       if (!string.empty()) {
         throw std::out_of_range("Not enough space in this ring buffer");
       }
-    } else if (begin <= end()) {
+    } else if (begin_ <= end()) {
       std::size_t space_before_overflow =
-          static_cast<std::size_t>(data.size() - end());
+          static_cast<std::size_t>(data_.size() - end());
       std::size_t bytes_to_write_to_r =
           std::min(string.size(), space_before_overflow);
-      string.copy(&data.data()[end()], bytes_to_write_to_r);
-      _size += bytes_to_write_to_r;
+      string.copy(&data_.data()[end()], bytes_to_write_to_r);
+      size_ += bytes_to_write_to_r;
       if (bytes_to_write_to_r != string.size()) {
         insert(string.substr(bytes_to_write_to_r));
       }
     } else {
       std::size_t space_before_overflow =
-          static_cast<std::size_t>(begin - end());
+          static_cast<std::size_t>(begin_ - end());
       if (string.size() > space_before_overflow) {
         throw std::out_of_range("Not enough space in this ring buffer");
       }
-      string.copy(&data.data()[end()], string.size());
-      _size += string.size();
+      string.copy(&data_.data()[end()], string.size());
+      size_ += string.size();
     }
   }
 
@@ -67,16 +67,16 @@ class StringRingBuffer {
    * @brief Get the current string in the buffer.
    */
   std::string peek() {
-    if (_size == 0) {
+    if (size_ == 0) {
       return "";
     }
-    if (begin < end()) {
-      return std::string(&data.data()[begin],
-                         static_cast<std::size_t>(end() - begin));
+    if (begin_ < end()) {
+      return std::string(&data_.data()[begin_],
+                         static_cast<std::size_t>(end() - begin_));
     } else {
-      return std::string(&data.data()[begin],
-                         static_cast<std::size_t>(data.size() - begin)) +
-             std::string(&data.data()[0], end());
+      return std::string(&data_.data()[begin_],
+                         static_cast<std::size_t>(data_.size() - begin_)) +
+             std::string(&data_.data()[0], end());
     }
   }
 
@@ -91,24 +91,24 @@ class StringRingBuffer {
       throw std::out_of_range("Not enough bytes in this ring buffer");
     }
 
-    if (begin <= end()) {
-      begin += bytes;
-      _size -= bytes;
+    if (begin_ <= end()) {
+      begin_ += bytes;
+      size_ -= bytes;
 
-      if (begin >= data.size()) {
-        begin = 0;
+      if (begin_ >= data_.size()) {
+        begin_ = 0;
       }
     } else {
       std::size_t space_before_overflow =
-          static_cast<std::size_t>(data.size() - begin);
+          static_cast<std::size_t>(data_.size() - begin_);
       std::size_t bytes_to_discard_now = std::min(bytes, space_before_overflow);
-      _size -= bytes_to_discard_now;
+      size_ -= bytes_to_discard_now;
 
       if (bytes_to_discard_now != bytes) {
-        begin = 0;
+        begin_ = 0;
         discard(bytes - bytes_to_discard_now);
       } else {
-        begin += bytes_to_discard_now;
+        begin_ += bytes_to_discard_now;
       }
     }
   }
@@ -117,22 +117,22 @@ class StringRingBuffer {
   /**
    * @brief Index of the first filled data point.
    *
-   * @warning if @p _size is `0`, then this index has no data and means
+   * @warning if @p size_ is `0`, then this index has no data and means
    *          nothing.
    */
-  std::size_t begin = 0;
+  std::size_t begin_ = 0;
 
   /**
    * @brief The number characters stored in this ring buffer.
    */
-  std::size_t _size = 0;
+  std::size_t size_ = 0;
 
-  std::array<char, N> data;
+  std::array<char, N> data_;
 
   /**
    * @brief Index of the first unfilled data point.
    */
-  std::size_t end() { return (begin + _size) % data.size(); }
+  std::size_t end() { return (begin_ + size_) % data_.size(); }
 };
 
 #endif /* NQM_IRIMAGER_STRING_RING_BUFFER */


### PR DESCRIPTION
**This PR depends on**:
  - #71

Please switch the target branch for this PR to `main` after the above PR has been merged.

---

Following the [Google C++ style guide][1][^1], class data members should have a trailing underscore in their variable name, e.g. `a_class_data_member_`.

This makes it easier to see whether a variable is being used from a local scope or the class scope, especially since in constructors, we often have function parameters that have the same name as class member variables.

[1]: https://google.github.io/styleguide/cppguide.html#Variable_Names

---

Since this might change the output binaries, I've made this a `refactor:` commit instead of a `style:` commit, and I'm **not** going to put it into the [`.git-blame-ignore-revs` file](https://github.com/nqminds/nqm-irimager/blob/16983e37e3c1912bc0e8399707d53abfea8e51d9/.git-blame-ignore-revs). I think this commit is pretty low-risk for breaking anything, but it's not a zero-risk change, so it's worth being able to see the `git blame` history.

[^1]: And also @TobyEalden's recommendation in https://github.com/nqminds/nqm-irimager/pull/67#pullrequestreview-1696515865