### PR TITLE
perf: use internal linkage when possible

### DIFF
--- a/src/nqm/irimager/irimager_class.cpp
+++ b/src/nqm/irimager/irimager_class.cpp
@@ -102,6 +102,8 @@ struct IRImagerMockImpl final : public IRImager::impl {
 #include <libirimager/IRImager.h>
 #include <libirimager/IRLogger.h>
 
+namespace {
+
 /**
  * Exception class to convert evo::IRDeviceError to a human readable error.
  */
@@ -364,6 +366,8 @@ struct IRImagerRealImpl final : public IRImager::impl {
     data->thermal_data_available.notify_one();
   }
 };
+
+}  // namespace
 
 #define IRImagerDefaultImplementation IRImagerRealImpl
 #endif /* ifdef IR_IMAGER_MOCK */

--- a/src/nqm/irimager/irlogger_to_spd_posix.cpp
+++ b/src/nqm/irimager/irlogger_to_spd_posix.cpp
@@ -38,6 +38,8 @@ extern "C" {
 #include "./chrono.hpp"
 #include "./irlogger_parser.hpp"
 
+namespace {
+
 /** RAII wrapper to handle reading from a POSIX FIFO */
 class PosixFileReadOnly {
  public:
@@ -268,7 +270,7 @@ class IRLoggerReader {
  * 0. If we're in the last bit of a second, block this function from returning
  * until the next second to avoid race-conditions.
  */
-static std::filesystem::path irlogger_log_path(
+std::filesystem::path irlogger_log_path(
     const std::filesystem::path &irlogger_log_path_prefix,
     std::chrono::milliseconds delay_if_at_end_of_second =
         std::chrono::milliseconds(100)) {
@@ -280,12 +282,16 @@ static std::filesystem::path irlogger_log_path(
          ".log";
 }
 
+}  // namespace
+
 #ifdef IR_IMAGER_MOCK
 
 #include <chrono>
 #include <fstream>
 #include <iostream>
 #include <thread>
+
+namespace {
 
 /**
  * Mock class that logs data to given socket.
@@ -323,9 +329,12 @@ class IRLoggerImpl {
     irlogger_mock_thread.get();
   }
 };
+}  // namespace
 #else /* IR_IMAGER_MOCK */
 
 #include <libirimager/IRLogger.h>
+
+namespace {
 
 /**
  * @brief Run the given function with a timeout.
@@ -406,6 +415,7 @@ class IRLoggerImpl {
     }
   }
 };
+}  // namespace
 #endif /* IR_IMAGER_MOCK */
 
 struct IRLoggerToSpd::impl {


### PR DESCRIPTION
**This PR depends on**:
  - #71

Please switch the target branch for this PR to `main` after the above PR has been merged.

---

Change as much of `src/nqm/irimager/irlogger_to_spd_posix.cpp` and `src/nqm/irimager/irimager_class.cpp` as possible to have [internal linkage][1] by using an [unnamed namespace][2].

This allows the compiler to perform more optimizations while compiling objects.

Previously, we were also getting a `‘IRImagerRealImpl’ declared with greater visibility than the type of its field ‘IRImagerRealImpl::thermal_data’ [-Wattributes]` warning, due to using a `pybind11::array_t` type (which [pybind11 internally forces hidden visibility][3]), but with PR https://github.com/nqminds/nqm-irimager/pull/64, this is no longer an issue.

[1]: https://en.cppreference.com/w/cpp/language/storage_duration#Linkage
[2]: https://en.cppreference.com/w/cpp/language/namespace#Unnamed_namespaces
[3]: https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes