### PR TITLE
Optimize `std::regex` in `IRLoggerParser` C++ class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,10 +76,7 @@ testpaths = [
     "tests",
     "build/tests",
 ]
-# the slowest test is
-# build/tests/test_irlogger_parser::test_irlogger_parser::HandlesLargeInputs,
-# which can take more than 10s in GitHUb Actions
-timeout = 20
+timeout = 10 # each test should finish within 5 seconds
 
 [tool.pdm.dev-dependencies]
 lint = [

--- a/src/nqm/irimager/irlogger_parser.cpp
+++ b/src/nqm/irimager/irlogger_parser.cpp
@@ -23,9 +23,9 @@ static const std::unordered_map<std::string, LogLevel>
  * @throws std::logic_error if parsing the IRLogger log line failed.
  */
 static std::tuple<LogLevel, std::string> parse_line(const std::string &line) {
-  const thread_local auto regex =
-      std::regex(R"""((\w+)\ \[([\w.:\d]*)\]\ \@\ ([\d\.]+s)\ :(.*))""",
-                 std::regex_constants::ECMAScript);
+  const thread_local auto regex = std::regex(
+      R"""((\w+)\ \[([\w.:\d]*)\]\ \@\ ([\d\.]+s)\ :(.*))""",
+      std::regex_constants::ECMAScript | std::regex_constants::optimize);
 
   std::smatch match_results;
 

--- a/src/nqm/irimager/irlogger_parser.cpp
+++ b/src/nqm/irimager/irlogger_parser.cpp
@@ -23,7 +23,7 @@ static const std::unordered_map<std::string, LogLevel>
  * @throws std::logic_error if parsing the IRLogger log line failed.
  */
 static std::tuple<LogLevel, std::string> parse_line(const std::string &line) {
-  auto regex =
+  const thread_local auto regex =
       std::regex(R"""((\w+)\ \[([\w.:\d]*)\]\ \@\ ([\d\.]+s)\ :(.*))""",
                  std::regex_constants::ECMAScript);
 


### PR DESCRIPTION
Constructing the [`std::regex`](https://en.cppreference.com/w/cpp/regex/basic_regex) is very slow, with the `build/tests/test_irlogger_parser::test_irlogger_parser.HandlesLargeInputs` test (which constructs this var multiple times) taking 5.5s on my laptop.

Using [`thread_local`](https://en.cppreference.com/w/cpp/language/storage_duration) means that we can keep a single cached copy per thread, and it increases the speed of the `parse_line()` function by 10x!!! The `test_irlogger_parser.HandlesLargeInputs` now only takes ~0.5s instead of 5.5s.

---

I've also enabled compiling the regex with [`std::regex_constants::optimize`](https://en.cppreference.com/w/cpp/regex/syntax_option_type) (added in C++17). This makes creating the regex slower (which is fine, since we only do it once), but it speeds up matching.

---

By the way, `std::regex` is one of the slower regex libraries in C++ (see https://stackoverflow.com/questions/70583395/why-is-stdregex-notoriously-much-slower-than-other-regular-expression-librarie), but it's probably fast enough for our use case, since 500ms for a test isn't too bad.
