### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2023-10-30
+
+Initial release.
+
+[unreleased]: https://github.com/nqminds/nqm-irimager/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/nqminds/nqm-irimager/releases/tag/v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nqm.irimager"
-version = "0.1.0a0" # equivalent to 0.1.0-alpha.0
+version = "1.0.0"
 description = "Python module for interfacing with EvoCortex IRImagerDirect SDK"
 # Python 3.12 removes distutils, which seems to break stuff
 # and prevents installing this package, see https://peps.python.org/pep-0632
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha", # currently only contains mocked interfaces
+  "Development Status :: 5 - Production/Stable",
   "Topic :: System :: Hardware :: Hardware Drivers",
   "Topic :: Multimedia :: Graphics :: Capture :: Digital Camera",
   "Intended Audience :: Developers",


### PR DESCRIPTION
Publish `nqm.irimager` to PyPI now that we have an minimum viable working codebase with a real thermal camera.

Published to https://pypi.org/project/nqm.irimager/1.0.0/

Currently, we have pre-compiled binaries for `arm64` and `x86_64` for Python 3.8 to Python 3.11, and the binaries include all the libraries we need!

