### PR TITLE
ci(build): add `url` to `pypi` environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,9 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/project/nqm.irimager/
     permissions:
       id-token: write
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
This is pretty minor, but adding a `url` field to an environment will be used by GitHub's deployments API, see
https://docs.github.com/en/actions/using-jobs/using-environments-for-jobs

