### PR TITLE
build: add `[project.urls]` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 
+[project.urls]
+Homepage = "https://github.com/nqminds/nqm-irimager"
+Repository = "https://github.com/nqminds/nqm-irimager.git"
+
 [build-system]
 requires = [
     "scikit-build-core>=0.4.7",


### PR DESCRIPTION
The Homepage URL is pretty important since it can decide whether PyPI considers our project active, see [PEP 541](https://peps.python.org/pep-0541/#abandoned-projects).

Without this, after 12 months with no releases, they can declare our package abandoned. Having a homepage means any activity on our GitHub page will prevent it from being declared abandoned.