### PR TITLE
docs: add @AshleySetter as a maintainer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.8, <3.12" # remember to manually sync with classifiers
 authors = [
     { name = "Alois Klink", email = "alois@nquiringminds.com" }
 ]
+maintainers = [
+    { name = "Ashley Setter", email = "ash@nquiringminds.com" }
+]
 readme = "README.md"
 
 dependencies = [


### PR DESCRIPTION
Hey @AshleySetter, I've invited [you](https://pypi.org/user/AshleySetter/) as an Owner to the [nqm.irimager package on PyPI](https://pypi.org/project/nqm.irimager/).

Side-note, we may want to consider up for an nqminds PyPI account. It's currently in Closed Beta (see https://docs.pypi.org/organization-accounts/), and it will cost money in the future, so :shrug: if it's worth it, but it would make sorting out permissions easier.

