### PR TITLE
ci(docs): publish docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,3 +35,17 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: ./build/html
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write      # needed to deploy to Pages
+      id-token: write   # needed to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,8 @@ jobs:
           path: ./build/html
 
   deploy:
+    name: publish docs (main-branch only)
+    if: github.ref == 'refs/heads/main'
     needs: build
     permissions:
       pages: write      # needed to deploy to Pages


### PR DESCRIPTION
Now that our `nqminds/nqm-irimager` GitHub repo is public (see https://github.com/nqminds/nqm-irimager/pull/79#issuecomment-1787464943), we might as well publish our docs to a public GitHub Pages website.