### PR TITLE
build: add `Typing :: Typed` PyPI classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Typing :: Typed",
 ]
 
 [build-system]


### PR DESCRIPTION
Add the `Typing :: Typed` [PyPI classifier](https://pypi.org/classifiers/), since our project contains type stubs.