### PR TITLE
feat: add `get_frame_monotonic()` Python method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `nqm.irimager.IRImager.get_frame_monotonic` Python method, which can be
   used to get the monotonic time of a frame directly from the
   EvoCortex IRImagerDirect SDK ([#84][]).
+- Add `nqm.irimager.monotonic_to_system_clock` function to convert a monotonic
+  time to a system clock time ([#84][]).
 
 [#81]: https://github.com/nqminds/nqm-irimager/pull/81
 [#84]: https://github.com/nqminds/nqm-irimager/pull/84

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   creates/deletes a
   [`nqm.logger.Logger`](https://nqminds.github.io/nqm-irimager/apidoc/nqm.irimager.html#nqm.irimager.Logger)
   object when used in a [`with:` statement][PEP 343] ([#81][]).
+- Add `nqm.irimager.IRImager.get_frame_monotonic` Python method, which can be
+  used to get the monotonic time of a frame directly from the
+  EvoCortex IRImagerDirect SDK ([#84][]).
 
 [#81]: https://github.com/nqminds/nqm-irimager/pull/81
+[#84]: https://github.com/nqminds/nqm-irimager/pull/84
 [PEP 343]: https://peps.python.org/pep-0343/
 
 ## [1.0.0] - 2023-10-30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ add_custom_command(
     --output "${CMAKE_CURRENT_BINARY_DIR}/docstrings.h"
     "-I;$<JOIN:$<TARGET_PROPERTY:irimager,INCLUDE_DIRECTORIES>,;-I;>"
     -std=c++17
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/nqm/irimager/chrono.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/nqm/irimager/irimager_class.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/nqm/irimager/logger_context_manager.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/nqm/irimager/logger.hpp"
@@ -191,6 +192,7 @@ target_compile_definitions(irimager PRIVATE "${IRImager_DEFINITIONS}")
 target_link_libraries(irimager
   PRIVATE
     pybind11::headers
+    spdlog::spdlog_header_only
     irimager_class
     irlogger_parser
     irlogger_to_spd

--- a/src/nqm/irimager/__init__.pyi
+++ b/src/nqm/irimager/__init__.pyi
@@ -24,6 +24,24 @@ __version__: str
 This is *not* the version of the underlying C++ libirimager library.
 """
 
+def monotonic_to_system_clock(
+    steady_time_point: datetime.timedelta,
+) -> datetime.datetime:
+    """
+    Converts from `steady_clock` to `system_clock`.
+
+    Converts a time_point from std::chrono::steady_clock (time since last boot)
+    to std::chrono::system_clock (aka time since UNIX epoch).
+
+    C++20 has a function called std::chrono::clock_cast that will do this
+    for us, but we're stuck on C++17, so instead we have to do this imprecise
+    monstrosity to do the conversion.
+
+    Remarks:
+        This function is imprecise!!! Calling it multiple times with the same
+        data will result in different results.
+    """
+
 class IRImager:
     """IRImager object - interfaces with a camera."""
 

--- a/src/nqm/irimager/__init__.pyi
+++ b/src/nqm/irimager/__init__.pyi
@@ -60,7 +60,19 @@ class IRImager:
               1. A 2-D matrix containing the image. This must be adjusted by
                  :py:meth:`~IRImager.get_temp_range_decimal` to get the actual
                  temperature in degrees Celcius, offset from -100 ℃.
-              2. The time the image was taken.
+              2. The approximate time the image was taken.
+        """
+    def get_frame_monotonic(
+        self,
+    ) -> typing.Tuple[npt.NDArray[np.uint16], datetime.timedelta]:
+        """Return a frame, with a monotonic/steady_clock timestamp.
+
+        Similar to :py:meth:`get_frame`, except returns a monotonic timepoint that the
+        IRImagerDirectSDK returns, which is more accurate.
+
+        Please be aware that the epoch of the monotonic timepoint is undefined,
+        and may be the time since last boot or the time since the program
+        started.
         """
     def get_temp_range_decimal(self) -> int:
         """The number of decimal places in the thermal data

--- a/src/nqm/irimager/__init__.pyi
+++ b/src/nqm/irimager/__init__.pyi
@@ -40,6 +40,12 @@ def monotonic_to_system_clock(
     Remarks:
         This function is imprecise!!! Calling it multiple times with the same
         data will result in different results.
+
+    Warning:
+        The monotonic/steady_clock might only count when the computer is powered
+        on. E.g. if the system was in a sleep state, the monotonic time may not
+        have increased. Because of this, you should not rely on this function
+        to return accurate results for past time points.
     """
 
 class IRImager:

--- a/src/nqm/irimager/chrono.hpp
+++ b/src/nqm/irimager/chrono.hpp
@@ -2,6 +2,10 @@
 #define CHRONO_HPP
 
 #include <chrono>
+#include <ctime>
+#include <sstream>
+#include <system_error>
+#include <thread>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/chrono.h>  // needed for logging/formatting std::chrono

--- a/src/nqm/irimager/chrono.hpp
+++ b/src/nqm/irimager/chrono.hpp
@@ -26,6 +26,12 @@ namespace irimager {
  * @remarks
  * This function is imprecise!!! Calling it multiple times with the same data
  * will result in different results.
+ *
+ * @warning
+ * The monotonic/steady_clock might only count when the computer is powered on.
+ * E.g. if the system was in a sleep state, the monotonic time may not have
+ * increased. Because of this, you should not rely on this function to return
+ * accurate results for past time points.
  */
 inline std::chrono::time_point<std::chrono::system_clock> clock_cast(
     const std::chrono::time_point<std::chrono::steady_clock>

--- a/src/nqm/irimager/irimager.cpp
+++ b/src/nqm/irimager/irimager.cpp
@@ -6,6 +6,7 @@
 #include <pybind11/stl/filesystem.h>
 #include <pybind11/stl_bind.h>
 
+#include "./chrono.hpp"
 #include "./irimager_class.hpp"
 #include "./logger.hpp"
 #include "./logger_context_manager.hpp"
@@ -43,6 +44,9 @@ to control these cameras.)";
 
   // helps prevent deadlock when calling code that doesn't touch Python objs
   const auto no_gil = pybind11::call_guard<pybind11::gil_scoped_release>();
+
+  m.def("monotonic_to_system_clock", &nqm::irimager::clock_cast,
+        DOC(nqm, irimager, clock_cast), no_gil);
 
   pybind11::class_<IRImager>(m, "IRImager", DOC(IRImager))
       .def(pybind11::init<const std::filesystem::path &>(),

--- a/src/nqm/irimager/irimager.cpp
+++ b/src/nqm/irimager/irimager.cpp
@@ -48,6 +48,8 @@ to control these cameras.)";
       .def(pybind11::init<const std::filesystem::path &>(),
            DOC(IRImager, IRImager), no_gil)
       .def("get_frame", &IRImager::get_frame, DOC(IRImager, get_frame), no_gil)
+      .def("get_frame_monotonic", &IRImager::get_frame_monotonic,
+           DOC(IRImager, get_frame_monotonic), no_gil)
       .def("get_temp_range_decimal", &IRImager::get_temp_range_decimal,
            DOC(IRImager, get_temp_range_decimal), no_gil)
       .def("get_library_version", &IRImager::get_library_version,
@@ -65,6 +67,8 @@ to control these cameras.)";
            DOC(IRImager, IRImager), no_gil)
       .def("get_frame", &IRImagerMock::get_frame, DOC(IRImager, get_frame),
            no_gil)
+      .def("get_frame_monotonic", &IRImager::get_frame_monotonic,
+           DOC(IRImager, get_frame_monotonic), no_gil)
       .def("get_temp_range_decimal", &IRImagerMock::get_temp_range_decimal,
            DOC(IRImager, get_temp_range_decimal), no_gil)
       .def("start_streaming", &IRImagerMock::start_streaming,

--- a/src/nqm/irimager/irimager_class.hpp
+++ b/src/nqm/irimager/irimager_class.hpp
@@ -92,9 +92,21 @@ class IRImager {
    *         1. A 2-D matrix containing the image. This must be adjusted
    *           by :py:meth:`~IRImager.get_temp_range_decimal` to get the
    *           actual temperature in degrees Celcius, offset from -100 ℃.
-   *         2. The time the image was taken.
+   *         2. The approximate time the image was taken.
    */
   std::tuple<ThermalFrame, std::chrono::system_clock::time_point> get_frame();
+
+  /**
+   * @brief Return a frame, with a monotonic/steady_clock timestamp.
+   *
+   * Similar to :py:meth:`get_frame`, except returns a monotonic timepoint that
+   * the IRImagerDirectSDK returns, which is more accurate.
+   *
+   * Please be aware that the epoch of the monotonic timepoint is undefined,
+   * and may be the time since last boot or the time since the program started.
+   */
+  std::tuple<ThermalFrame, std::chrono::steady_clock::time_point>
+  get_frame_monotonic();
 
   /**
    * The number of decimal places in the thermal data

--- a/tests/test_irimager.py
+++ b/tests/test_irimager.py
@@ -79,6 +79,24 @@ def test_irimager_get_frame():
         assert timestamp > datetime.datetime.now() - datetime.timedelta(seconds=30)
 
 
+def test_irimager_get_frame_monotonic():
+    """Tests nqm.irimager.IRImager#get_frame_monotonic"""
+    irimager = IRImager(XML_FILE)
+
+    with irimager:
+        array, steady_time = irimager.get_frame_monotonic()
+
+        assert array.dtype == np.uint16
+        # should be 2-dimensional
+        assert array.ndim == 2
+        assert array.shape == (382, 288)
+        assert array.flags["C_CONTIGUOUS"]  # check if the array is row-major
+
+        assert steady_time > datetime.timedelta(seconds=0)
+        array, steady_time_2 = irimager.get_frame_monotonic()
+        assert steady_time_2 > steady_time
+
+
 def test_irimager_get_temp_range_decimal():
     """Tests that nqm.irimager.IRImager#get_temp_range_decimal returns an int"""
     irimager = IRImager(XML_FILE)

--- a/tests/test_irimager.py
+++ b/tests/test_irimager.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from nqm.irimager import IRImagerMock as IRImager
-from nqm.irimager import Logger
+from nqm.irimager import Logger, monotonic_to_system_clock
 
 XML_FILE = pathlib.Path(__file__).parent / "__fixtures__" / "382x288@27Hz.xml"
 README_FILE = pathlib.Path(__file__).parent.parent / "README.md"
@@ -95,6 +95,13 @@ def test_irimager_get_frame_monotonic():
         assert steady_time > datetime.timedelta(seconds=0)
         array, steady_time_2 = irimager.get_frame_monotonic()
         assert steady_time_2 > steady_time
+
+    assert monotonic_to_system_clock(
+        steady_time
+    ) > datetime.datetime.now() - datetime.timedelta(seconds=30)
+    assert monotonic_to_system_clock(
+        steady_time_2
+    ) > datetime.datetime.now() - datetime.timedelta(seconds=30)
 
 
 def test_irimager_get_temp_range_decimal():


### PR DESCRIPTION
The [`evo::IRDevice::getFrame()`](http://documentation.evocortex.com/libirimager2/html/classevo_1_1IRDeviceUVC.html#a4f3dceabd6cc607c40773cae9fdd35b7) function doesn't return a UNIX timestamp when getting a frame. Instead it returns a monotonic/steady timestamp.

To convert this back to a `std::chrono::system_clock`, I've added a function called `nqm::irimager::clock_cast`, but it's imprecise, so it's not ideal for very high frame-rates. Instead, we may want to use a monotonic time directly.

---

@AshleySetter, if you ever need to calculate the time between frames, or the frame rate, you probably want to use this monotonic time instead, as it will be more accurate than a system time.

I don't know you're planning on storing the data, but if you're using the Volt or another database, you probably want to store both the monotonic/steady time, and the system time.

And if you're doing planning on storing the data using video compression (e.g. with a variable frame rate), monotonic time is the one you should go for!
