### PR TITLE
fix: improve accuracy of times from `get_frame()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `nqm.irimager.monotonic_to_system_clock` function to convert a monotonic
   time to a system clock time ([#84][]).
 
+### Fixed
+
+- Truncate timestamps to
+  [`std::chrono::steady_clock::duration`](https://en.cppreference.com/w/cpp/chrono/steady_clock)
+  instead of
+  [`std::chrono::nanoseconds`](https://en.cppreference.com/w/cpp/chrono/duration)
+  ([#86][]).
+
 [#81]: https://github.com/nqminds/nqm-irimager/pull/81
 [#84]: https://github.com/nqminds/nqm-irimager/pull/84
+[#86]: https://github.com/nqminds/nqm-irimager/pull/86
 [PEP 343]: https://peps.python.org/pep-0343/
 
 ## [1.0.0] - 2023-10-30

--- a/src/nqm/irimager/irimager_class.cpp
+++ b/src/nqm/irimager/irimager_class.cpp
@@ -278,13 +278,12 @@ struct IRImagerRealImpl final : public IRImager::impl {
 
     auto seconds_since_epoch =
         std::chrono::duration<double, std::ratio<1> >(timestamp);
-    auto nanoseconds_since_epoch =
-        std::chrono::floor<std::chrono::nanoseconds>(seconds_since_epoch);
 
     // need to convert our double duration to an integer duration
     auto monotonic_time_point =
         std::chrono::time_point<std::chrono::steady_clock>(
-            nanoseconds_since_epoch);
+            std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                seconds_since_epoch));
 
     return std::make_tuple(
         std::get<IRImager::ThermalFrame>(std::move(thermal_data_result)),


### PR DESCRIPTION
Currently, we're truncating all the timestamps from `nqm.irimager.IRImager.get_frame()` to the nanosecond level.

However, `std::chrono::steady_clock::period` may be higher than 1e9, so we're losing accuracy here.

Additionally, it could also be lower than 1e9, in which case we'd have a compiler error.